### PR TITLE
Fix warning in strlen() macro

### DIFF
--- a/bin/hxecd/hxecd.h
+++ b/bin/hxecd/hxecd.h
@@ -153,7 +153,7 @@ void do_trap_htx64(unsigned long, ...);
 #include <string.h>
 
 #define strlen(_X_)\
-        ( (size_t) ( (_X_) ? strlen(_X_) : NULL ) )
+        (  (_X_) ? strlen(_X_) : (size_t) NULL )
 
 #define strcpy(_D_,_S_)\
         ( (_D_) ? (_S_) ? strcpy(_D_,_S_) : (_D_) : NULL )


### PR DESCRIPTION
This fixes a lot of warnings in the build:

  hxecd.h:156:42: warning: pointer/integer type mismatch in conditional expression
       ( (size_t) ( (_X_) ? strlen(_X_) : NULL ) )
