### PR TITLE
Remove last remnants of building_htx.txt

### DIFF
--- a/Documentation/HTX_user_manual.txt
+++ b/Documentation/HTX_user_manual.txt
@@ -16,7 +16,7 @@ HTX User Manual
 1.1 Obtaining and building HTX source 
 
 	HTX source can be downloaded from Github (https://github.com/open-power/HTX).
-	To build HTX source, please refer, <HTX source>/Documentation/building_htx.txt.
+	To build HTX source, please refer, <HTX source>/README.md.
 
 1.2 Setting up the System to Install HTX 
 

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -1,6 +1,6 @@
 include ../htx.mk
 
-TARGET= equaliser.readme building_htx.txt HTX_user_manual.txt \
+TARGET= equaliser.readme HTX_user_manual.txt \
 	HTX_developers_manual.txt htxd_user_manual.pdf network_setup_procedure.txt
 
 .PHONY: all clean


### PR DESCRIPTION
There was a mention of it in another Documentation file, and a
Makefile rule.

Signed-off-by: Anton Blanchard <anton@samba.org>