### PR TITLE
Logical operator used when bitwise operator wanted

### DIFF
--- a/bin/hxefpu64/bfp_global.c
+++ b/bin/hxefpu64/bfp_global.c
@@ -934,7 +934,7 @@ void class_bfp_qp_round_gen(uint32 client_no, uint32 random_no, struct instructi
 	 * that it becomes valid.
 	 */
 
-	rmode = random_no && 0x7;	/* Get last 3 bits */
+	rmode = random_no & 0x7;	/* Get last 3 bits */
 	if ( rmode == 0x1 || rmode == 0x2 ) {
 		/* Handling reserved case */
 		rmode |= 0x4; /* Set R=1 to make it valid */


### PR DESCRIPTION
Catch another place where we used && but meant to use &.

Signed-off-by: Anton Blanchard <anton@samba.org>