### PR TITLE
Fix atexit() usage

### DIFF
--- a/bin/hxefpu64/framework.c
+++ b/bin/hxefpu64/framework.c
@@ -4886,9 +4886,10 @@ create_context(int client_no)
 	 }
 	 return(0);
 }
-int cleanup_mem_atexit(){
-    cleanup_mem(0);
-    return(0);
+
+void cleanup_mem_atexit(void)
+{
+	cleanup_mem(0);
 }
 
 int

--- a/bin/hxefpu64/framework.h
+++ b/bin/hxefpu64/framework.h
@@ -1161,7 +1161,7 @@ int execute_testcase(int, int);
 int compare_results(int, int *);
 int allocate_mem(struct shm_buf *);
 int cleanup_mem(int);
-int cleanup_mem_atexit(void);
+void cleanup_mem_atexit(void);
 int read_rf(void);
 void set_rule_defaults(void);
 int get_rule(int *, FILE *, struct ruleinfo *);


### PR DESCRIPTION
atexit() takes a function that returns void, so fix cleanup_mem_atexit()
to match.

Signed-off-by: Anton Blanchard <anton@samba.org>