### PR TITLE
Fix some operator precedence issues

### DIFF
--- a/bin/hxecom/comread.c
+++ b/bin/hxecom/comread.c
@@ -1381,7 +1381,7 @@ static int headerCkFail(char rbuf[], char MsgStr[])
     if(rbuf[TP_SEQ_LEN] != '\0')
         error = 1;
     sum += (unsigned char)rbuf[TP_TIME_POS];
-    if(0xff & sum != (unsigned char)rbuf[TP_HDR_LEN -1])
+    if((0xff & sum) != (unsigned char)rbuf[TP_HDR_LEN -1])
         error = 1;
     if(error) {
         sprintf(MsgStr, "Header Error \"");

--- a/bin/hxecom/comread_rdma.c
+++ b/bin/hxecom/comread_rdma.c
@@ -338,7 +338,7 @@ static int headerCkFail(char rbuf[], char MsgStr[])
     if(rbuf[TP_SEQ_LEN] != '\0')
         error = 1;
     sum += (unsigned char)rbuf[TP_TIME_POS];
-    if(0xff & sum != (unsigned char)rbuf[TP_HDR_LEN -1])
+    if((0xff & sum) != (unsigned char)rbuf[TP_HDR_LEN -1])
         error = 1;
     if(error) {
         sprintf(MsgStr, "Header Error \"");

--- a/bin/hxecom/rule.c
+++ b/bin/hxecom/rule.c
@@ -439,7 +439,7 @@ int get_rule(FILE *fd, int *line, struct rule_format * r_ptr)
  		/* that don't specify OPER -- if Master, OPER=RW. if not master, OPER=W.    */
 		/****************************************************************************/
     	if(error == 'n' && (r_ptr->transact & (WRITE_VAL | READ_VAL)) == 0) {
-       		if(r_ptr->transact & MASTER_VAL == 0)
+		if((r_ptr->transact & MASTER_VAL) == 0)
            		r_ptr->transact |= WRITE_VAL;
        		else
            		r_ptr->transact |= (WRITE_VAL | READ_VAL);


### PR DESCRIPTION
clang warnings uncovered a few issues:

hxecom/comread.c:1384:13: warning: & has lower precedence than !=; != will be evaluated first [-Wparentheses]

	if(0xff & sum != (unsigned char)rbuf[TP_HDR_LEN -1])

hxecom/rule.c:442:29: warning: & has lower precedence than ==; == will be evaluated first [-Wparentheses]

	if(r_ptr->transact & MASTER_VAL == 0)

Both look like real bugs, so add parentheses to fix.

Signed-off-by: Anton Blanchard <anton@samba.org>