### PR TITLE
Enable build test in travis-ci infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+language: c
+
+services:
+ - docker
+
+before_install:
+ - docker build -t open-power/htx - < Dockerfile
+
+script:
+ - docker run -t -v `pwd`:/HTX:z open-power/htx /bin/sh -c "cd /HTX; ln -s /lib/powerpc64le-linux-gnu/libncurses.so.5  /lib/powerpc64le-linux-gnu/libncurses.so; ln -s /lib/powerpc64le-linux-gnu/libtinfo.so.5  /lib/powerpc64le-linux-gnu/libtinfo.so ; CC=powerpc64le-linux-gnu-gcc CPP=powerpc64le-linux-gnu-g++ AR=powerpc64le-linux-gnu-ar LD=powerpc64le-linux-gnu-ld AS=powerpc64le-linux-gnu-as make -j`grep -c processor /proc/cpuinfo`"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:16.04
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy make gcc-powerpc64le-linux-gnu  g++-powerpc64le-linux-gnu
+RUN dpkg --add-architecture ppc64el
+RUN sed -i -e 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list
+RUN echo 'deb [arch=ppc64el] http://ports.ubuntu.com/ubuntu-ports xenial main universe restricted' >> /etc/apt/sources.list
+RUN echo 'deb [arch=ppc64el] http://ports.ubuntu.com/ubuntu-ports xenial-security main universe restricted' >> /etc/apt/sources.list
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy libncurses5:ppc64el libncurses-dev libdapl-dev:ppc64el

--- a/bin/hxssup/Makefile
+++ b/bin/hxssup/Makefile
@@ -37,7 +37,7 @@ SRCS = $(patsubst %.o, %.c, $(OBJECTS))
 CFLAGS += -D_GNU_SOURCE
 
 LIBS += -Wl,--start-group
-LIBS += -lrt -lhtx64 -lpthread -lc -lcfgc64 -lncurses -lc
+LIBS += -lrt -lhtx64 -lpthread -lc -lcfgc64 -lncurses -ltinfo -lc
 LIBS += -Wl,--end-group
 
 .PHONY: all clean

--- a/htx.mk
+++ b/htx.mk
@@ -8,12 +8,13 @@ else
 ARCH=ppc64
 endif
 MKDIR=/bin/mkdir -p
-CC=/usr/bin/gcc -m64
-CPP=/usr/bin/g++ -m64
+AS?=/usr/bin/as
+CC?=/usr/bin/gcc -m64
+CPP?=/usr/bin/g++ -m64
 RM=/bin/rm
 CP=/bin/cp
-AR=/usr/bin/ar
-LD=/usr/bin/ld
+AR?=/usr/bin/ar
+LD?=/usr/bin/ld
 LDFLAGS=
 CFLAGS=-D__HTX_LINUX__ -DTRUE=1 -DFALSE=0 -D__64BIT__
 ifeq ($(HTX_RELEASE), $(filter ${HTX_RELEASE},"htxubuntu" "htxsles12" "htxrhel72le" "htxfedorale"))


### PR DESCRIPTION
This does a number of hacks^W neat tricks to cross-compile HTX on Ubuntu 16.04 in a docker container using the travis-ci.org infrastructure.

When you enable travis-ci for your repo, this means that on each push, travis will (for free) do a build test. If it fails, you get email.

We may want to name the Dockerfile something else of course.