### PR TITLE
Creating separate script for exporting HTX env variables

### DIFF
--- a/etc/scripts/Makefile
+++ b/etc/scripts/Makefile
@@ -41,7 +41,8 @@ TARGET = \
 	create_my_sctu_stanzas.awk \
 	check_disk \
 	get_mem_pool_details.sh \
-	htx_setup.sh 
+	htx_setup.sh \
+	htx_env.sh
 
 
 all: ${TARGET}

--- a/etc/scripts/htx_env.sh
+++ b/etc/scripts/htx_env.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Export variables
+  export USERNAME=htx
+  export HOST=$(/bin/hostname -s)
+  export PS1='
+($?) $USERNAME @ $HOST: $PWD
+# '
+  export TERM=vt100
+#  export HOME=/usr/lpp/htx/
+  export HTX_HOME_DIR=$HOME
+  export HTX_LOG_DIR=/tmp/
+  export LESS="-CdeiM"
+
+  export HTXLPP=$HTX_HOME_DIR
+  export HTXPATH=$HTX_HOME_DIR
+  export HTXLINUXLEVEL=${HTXLPP}/htxlinuxlevel # Its a file. Last / should not be there.
+  export HTXPATTERNS=${HTXLPP}/pattern/
+  export HTXRULES=${HTXLPP}/rules/
+  export HTXREGRULES=${HTXRULES}/reg/
+  export HTXECG=${HTXLPP}/ecg/
+  export HTXMDT=${HTXLPP}/mdt/
+  export HTXBIN=${HTXLPP}/bin/
+  export HTXETC=${HTXLPP}/etc/
+  export HTXSCREENS=${HTXLPP}/etc/screens/
+  export STXSCREENS=${HTXLPP}/etc/screens_stx/
+  export HTXMISC=${HTXLPP}/etc/misc/
+  export HTXTMP=$HTX_LOG_DIR
+  export HTXSETUP=${HTXLPP}/setup/
+  export HTXRUNSETUP=${HTXLPP}/runsetup/
+  export HTXRUNCLEANUP=${HTXLPP}/runcleanup/
+  export HTXCLEANUP=${HTXLPP}/cleanup/
+  export HTXPROCESSORS=1
+  export HTXSCRIPTS=${HTXLPP}/etc/scripts/
+  export HTXSCRIPTS_STX=${HTXLPP}/etc/scripts_stx/
+  export HTXNoise=$HTX_LOG_DIR/HTXScreenOutput # Its a file. Last / should not be there
+
+# Directory commands
+  alias ksh="bash"
+  alias mdt="cd $HTXMDT"
+  alias reg="cd $HTXREGRULES"
+  alias emc="cd $HTXEMCRULES"
+  alias rules="cd $HTXRULES"
+  alias bin="cd $HTXBIN"
+  alias tvi=/bos/k/bin/vi
+  alias em="emacs =100x38+0+0"
+  alias e="xe"
+  alias li="/bin/li -v"
+  alias liv="/bin/li -v vmm*"
+  alias ll="/bin/li -lv"
+  alias llv="/bin/li -lv vmm*"
+  alias llx="/bin/li -lv xix*"
+
+# Screen management commands
+  alias cls="tput clear"
+  alias bye="tput clear; exit"
+  alias win="open ksh; tput clear"
+
+# System management commands
+  alias kmake=/bos/k/bin/make
+  alias lml="lm list=list"
+  alias print=/bin/print
+  alias pq="/bin/print -q"
+  alias pspg="ps -ef | pg"
+  alias rb="remsh bdslab"
+  alias pnum="rexec bcroom pnum"
+  alias cnum="rexec bcroom cnum"
+  alias dept="rexec bcroom dept"
+  alias man="man -e/bin/pg"
+  alias manv3="manv3 -e/bin/pg"
+  alias nmake="nmake -u"
+  alias s="echo 'sync;sync;sync;sync';sync;sync;sync;sync"
+
+# Miscellaneous commands
+  alias de="daemon emacs"
+  alias dx="daemon xant"
+
+# HTX commands
+  set -o ignoreeof
+  set -o vi
+

--- a/etc/scripts/htx_setup.sh
+++ b/etc/scripts/htx_setup.sh
@@ -131,92 +131,6 @@ function ttyis
 }
 
 
-
-# Export variables
-  export USERNAME=htx
-  export HOST=$(/bin/hostname -s)
-  export PS1='
-($?) $USERNAME @ $HOST: $PWD
-# '
-  export TERM=vt100
-  export HOME=/usr/lpp/htx/
-  export HTX_HOME_DIR=$HOME
-  export HTX_LOG_DIR=/tmp/
-  export LESS="-CdeiM"
-
-  export HTXLPP=$HTX_HOME_DIR
-  export HTXPATH=$HTX_HOME_DIR
-  export HTXLINUXLEVEL=${HTXLPP}/htxlinuxlevel # Its a file. Last / should not be there.
-  export HTXPATTERNS=${HTXLPP}/pattern/
-  export HTXRULES=${HTXLPP}/rules/
-  export HTXREGRULES=${HTXRULES}/reg/
-  export HTXECG=${HTXLPP}/ecg/
-  export HTXMDT=${HTXLPP}/mdt/
-  export HTXBIN=${HTXLPP}/bin/
-  export HTXETC=${HTXLPP}/etc/
-  export HTXSCREENS=${HTXLPP}/etc/screens/
-  export STXSCREENS=${HTXLPP}/etc/screens_stx/
-  export HTXMISC=${HTXLPP}/etc/misc/
-  export HTXTMP=$HTX_LOG_DIR
-  export HTXSETUP=${HTXLPP}/setup/
-  export HTXRUNSETUP=${HTXLPP}/runsetup/
-  export HTXRUNCLEANUP=${HTXLPP}/runcleanup/
-  export HTXCLEANUP=${HTXLPP}/cleanup/
-  export HTXPROCESSORS=1
-  export HTXSCRIPTS=${HTXLPP}/etc/scripts/
-  export HTXSCRIPTS_STX=${HTXLPP}/etc/scripts_stx/
-  export HTXNoise=$HTX_LOG_DIR/HTXScreenOutput # Its a file. Last / should not be there
-
-# Directory commands
-  alias ksh="bash"
-  alias mdt="cd $HTXMDT"
-  alias reg="cd $HTXREGRULES"
-  alias emc="cd $HTXEMCRULES"
-  alias rules="cd $HTXRULES"
-  alias bin="cd $HTXBIN"
-  alias tvi=/bos/k/bin/vi
-  alias em="emacs =100x38+0+0"
-  alias e="xe"
-  alias li="/bin/li -v"
-  alias liv="/bin/li -v vmm*"
-  alias ll="/bin/li -lv"
-  alias llv="/bin/li -lv vmm*"
-  alias llx="/bin/li -lv xix*"
-
-# Screen management commands
-  alias cls="tput clear"
-  alias bye="tput clear; exit"
-  alias win="open ksh; tput clear"
-
-# System management commands
-  alias kmake=/bos/k/bin/make
-  alias lml="lm list=list"
-  alias print=/bin/print
-  alias pq="/bin/print -q"
-  alias pspg="ps -ef | pg"
-  alias rb="remsh bdslab"
-  alias pnum="rexec bcroom pnum"
-  alias cnum="rexec bcroom cnum"
-  alias dept="rexec bcroom dept"
-  alias man="man -e/bin/pg"
-  alias manv3="manv3 -e/bin/pg"
-  alias nmake="nmake -u"
-  alias s="echo 'sync;sync;sync;sync';sync;sync;sync;sync"
-
-# Miscellaneous commands
-  alias de="daemon emacs"
-  alias dx="daemon xant"
-
-# HTX commands
-  set -o ignoreeof
-  set -o vi
-  alias logout=". ${HTXSCRIPTS}/htxlogout"
-  alias exit=". ${HTXSCRIPTS}/htxlogout"
-  alias htx=". runsup"
-  alias stx="$HTXSCRIPTS_STX/runstx"
-  alias stopstx="$HTXSCRIPTS_STX/stopstx"
-
-
 # Check if this script is invoked by root/equivalent. 
 # If not, then return with error
   if [[ $EUID -ne 0 ]]; then
@@ -224,9 +138,11 @@ function ttyis
     exit 1
   fi
 
-
 # HTXNoise is a repository for HTX screen activity during login and runsup commands.
 # This is an attempt to capture errors that may otherwise be lost
+
+  # 1st message is invoked directly rather than using print_htx_log since we needed
+  # to create a new file (clear content). Leave it like this. 
   echo "[`date`]: 1st HTX message." | tee $HTXNoise
 
 # Check whether HTX is already running on system
@@ -235,6 +151,7 @@ function ttyis
      exit 1
   }
 
+  export HOME=/usr/lpp/htx/
   PATH=$HOME
   PATH=$PATH:$HOME/etc/scripts
   PATH=$PATH:$HOME/etc
@@ -252,7 +169,19 @@ function ttyis
   PATH=$PATH:$HOME/test/tools
   PATH=$PATH:.
   export PATH
+
   print_htx_log "exporting PATH=$PATH"
+
+# Source htx_env.sh so that all exports and alias become available.
+  . htx_env.sh
+
+# Setting HTX environment specific alias
+  alias logout=". ${HTXSCRIPTS}/htxlogout"
+  alias exit=". ${HTXSCRIPTS}/htxlogout"
+  alias htx=". runsup"
+  alias stx="$HTXSCRIPTS_STX/runstx"
+  alias stopstx="$HTXSCRIPTS_STX/stopstx"
+
 
   os_distribution=`grep ^NAME /etc/os-release | cut -f2 -d= | sed s/\"//g`
   if [ $os_distribution == "Ubuntu" ]

--- a/etc/scripts/htxconf.awk
+++ b/etc/scripts/htxconf.awk
@@ -500,7 +500,7 @@ BEGIN {
     }
 
     corsa_capi_present = snarf("ls /dev/cxl/afu0.0s 2> /dev/null | wc -l");
-    corsa_dev_type = snarf("cat /sys/class/cxl/afu0.0s/device/cr0/device");
+    corsa_dev_type = snarf("cat /sys/class/cxl/afu0.0s/device/cr0/device 2> /dev/null");
     if ( corsa_capi_present == "1" && corsa_dev_type == "0x0602" ) {
                 if((CMVC_RELEASE == "htxrhel72le") || (CMVC_RELEASE == "htxrhel7") || (CMVC_RELEASE == "htxubuntu")) {
                         mkstanza("hxecorsa", "chip", "Misc", "afu0.0s", "hxecorsa", "default.capi", "" );


### PR DESCRIPTION
Creating new htx_env.sh script which takes care of exporting all HTX related environment variables.
This can be independently called outside of 'su - htx' environment also so that other independent
htx scripts could create same environment as well. 