### PR TITLE
Please refer to original pull request #32 for background. CPP?= shoul…

### DIFF
--- a/bin/hxeasy/Makefile
+++ b/bin/hxeasy/Makefile
@@ -17,11 +17,11 @@ LIBS =-lpthread -lhtx64
 .PHONY: all clean
 
 all: ${OBJECTS}
-	${CPP} ${LDFLAGS} ${LIBPATH} ${OBJECTS} ${LIBS} -o ${TARGET}
+	${CXX} ${LDFLAGS} ${LIBPATH} ${OBJECTS} ${LIBS} -o ${TARGET}
 	${CP} ${TARGET} ${SHIPBIN}
 
 %.o: %.C
-	${CPP} ${CFLAGS} ${INCLUDES} -c $< -o $@
+	${CXX} ${CFLAGS} ${INCLUDES} -c $< -o $@
 
 clean:
 	${RM} -f *.o ${TARGET} ${SHIPBIN}/${TARGET}

--- a/htx.mk
+++ b/htx.mk
@@ -10,7 +10,7 @@ endif
 MKDIR=/bin/mkdir -p
 AS?=/usr/bin/as
 CC?=/usr/bin/gcc -m64
-CPP?=/usr/bin/g++ -m64
+CXX?=/usr/bin/g++ -m64
 RM=/bin/rm
 CP=/bin/cp
 AR?=/usr/bin/ar


### PR DESCRIPTION
…d be replaced with CXX?= because CPP has default assignment of CC -E which is breaking compilation of HTX CPP programs