### PR TITLE
Updating PATH and HOME for htx_env setup script. Minor change in htx64 lib

### DIFF
--- a/etc/scripts/htx_env.sh
+++ b/etc/scripts/htx_env.sh
@@ -7,10 +7,28 @@
 ($?) $USERNAME @ $HOST: $PWD
 # '
   export TERM=vt100
-#  export HOME=/usr/lpp/htx/
+  export HOME=/usr/lpp/htx/
   export HTX_HOME_DIR=$HOME
   export HTX_LOG_DIR=/tmp/
   export LESS="-CdeiM"
+
+  PATH=$PATH:$HOME
+  PATH=$PATH:$HOME/etc/scripts
+  PATH=$PATH:$HOME/etc
+  PATH=$PATH:$HOME/etc/methods
+  PATH=$PATH:$HOME/bin
+  PATH=$PATH:/bin
+  PATH=$PATH:/sbin
+  PATH=$PATH:/usr/bin
+  PATH=$PATH:/usr/sbin
+  PATH=$PATH:/usr/ucb
+  PATH=$PATH:/usr/bin/X11
+  PATH=$PATH:/etc
+  PATH=$PATH:/test/tools
+  PATH=$PATH:/usr/local/bin
+  PATH=$PATH:$HOME/test/tools
+  PATH=$PATH:.
+  export PATH
 
   export HTXLPP=$HTX_HOME_DIR
   export HTXPATH=$HTX_HOME_DIR

--- a/etc/scripts/htx_setup.sh
+++ b/etc/scripts/htx_setup.sh
@@ -151,29 +151,11 @@ function ttyis
      exit 1
   }
 
-  export HOME=/usr/lpp/htx/
-  PATH=$HOME
-  PATH=$PATH:$HOME/etc/scripts
-  PATH=$PATH:$HOME/etc
-  PATH=$PATH:$HOME/etc/methods
-  PATH=$PATH:$HOME/bin
-  PATH=$PATH:/bin
-  PATH=$PATH:/sbin
-  PATH=$PATH:/usr/bin
-  PATH=$PATH:/usr/sbin
-  PATH=$PATH:/usr/ucb
-  PATH=$PATH:/usr/bin/X11
-  PATH=$PATH:/etc
-  PATH=$PATH:/test/tools
-  PATH=$PATH:/usr/local/bin
-  PATH=$PATH:$HOME/test/tools
-  PATH=$PATH:.
-  export PATH
-
-  print_htx_log "exporting PATH=$PATH"
 
 # Source htx_env.sh so that all exports and alias become available.
   . htx_env.sh
+
+  print_htx_log "exporting PATH=$PATH"
 
 # Setting HTX environment specific alias
   alias logout=". ${HTXSCRIPTS}/htxlogout"

--- a/lib/htx64/hxfupdate.c
+++ b/lib/htx64/hxfupdate.c
@@ -435,6 +435,7 @@ int hxfupdate_tunsafe(char call, struct htx_data *data)
         p_shm_HE->err_ack = 0;
 
 		htx_update(data);  
+		htx_get_msg(data, msg_send);
 		htx_error(data,msg_send);
 
 		if (!((strcmp (data->run_type, "REG") != 0) && (strcmp (data->run_type, "EMC") != 0))) {


### PR DESCRIPTION
Adding PATH and HOME setting in htx_env script which gets called outside of HTX environment as well.
Earlier it was done in htx_setup script and hence creating problem for standalone htx scripts. 

One minor change in htx64 to care of fabricbus corner case. 