### PR TITLE
replace xscom code for VMX Crypto check with HWCAP2 alternative

### DIFF
--- a/bin/hxefpu64/framework.h
+++ b/bin/hxefpu64/framework.h
@@ -43,7 +43,9 @@
 	#include <sched.h>
 	#include <sys/prctl.h>
 	#include <sys/resource.h>
-	#include <xscom.h>
+	#if !defined (__BML__)
+	#include <sys/auxv.h>
+	#endif
 #else
 	#include <sys/dr.h>
 #endif
@@ -60,10 +62,7 @@
 #endif
 
 #ifdef SCTU
-#define LOGFILE		"/tmp/sctu_log"
 #define SCTU_PP_COUNT	(256)
-#else
-#define LOGFILE		"/tmp/fpu_log"
 #endif
 
 #define HSTRCMP strcasecmp
@@ -848,6 +847,7 @@ extern struct server_data global_sdata[];
 #define			BFP_COMPARE_ONLY		0x8000					|BFP_ONLY
 #define			BFP_SELECT_ONLY			0x10000					|BFP_ONLY
 #define			BFP_FPSCR_ONLY			0x20000					|BFP_ONLY
+#define			P9_BFP_FPSCR_ONLY		(0x20000				|BFP_ONLY 	|P9_ONLY)
 #define 		BFP_TEST_ONLY			0x40000					|BFP_ONLY
 #define 		P9_BFP_MOVE_ONLY		BFP_MOVE_ONLY			|BFP_ONLY	|P9_ONLY
 #define			P9_BFP_COMPARE_ONLY		BFP_COMPARE_ONLY		|BFP_ONLY   |P9_ONLY


### PR DESCRIPTION
The code works fine for our ubuntu 16-04 builds where the gcc ver is 5.4.0 20160609, it also works for gcc (SUSE Linux) 4.8.5. As of now we can enable VMX crypto detection except on BML where it fail to compile (gcc-4_3) 
pls see https://github.com/open-power/HTX/issues/54 for other details