### PR TITLE
show_syscfg doesn't take syscfg.rw lock on shared processor machines

### DIFF
--- a/bin/show_syscfg/show_syscfg.c
+++ b/bin/show_syscfg/show_syscfg.c
@@ -250,6 +250,10 @@ get_env_details(&e);
     get_hardware_stat(&Sys_stat);
 	int cores_exc = 0;
 	
+    rc1 = pthread_rwlock_rdlock(&(global_ptr->syscfg.rw));
+    if (rc1 !=0  ) {
+        printf("\n lock inside get_hardware_config failed with errno=%d\n",rc1);
+    }
 	if(!strcmp(e.proc_shared_mode,"yes"))
 	{
 		printf("Number of nodes \t\t\t: NA\n");
@@ -308,10 +312,6 @@ get_env_details(&e);
         	}
         	printf("\n");
     	}
-    rc1 = pthread_rwlock_rdlock(&(global_ptr->syscfg.rw));
-    if (rc1 !=0  ) {
-        printf("\n lock inside get_hardware_config failed with errno=%d\n",rc1);
-    }
 	
 
 		printf("\n\n--------------------------CPUS PER NODE-----------------------------\n");


### PR DESCRIPTION
pthread_rwlock_rdlock() is in the wrong place, and it is hard
to spot because the formatting of this file is very inconsistent.
