### PR TITLE
Adding hxediag support to test new adapters/drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ TARGET= .htx_profile \
         .bash_profile \
         .bashrc \
         htx_eq.cfg \
+        htx_diag.config \
 	run_htx_cmdline.sh \
         hxsscripts
 

--- a/bin/hxediag/hxediag.h
+++ b/bin/hxediag/hxediag.h
@@ -58,6 +58,18 @@
 
 #define MAX_RETRY	0x10
 
+#define NVRAM_MASK 	0x01
+#define LINK_MASK 	0x02
+#define REGISTER_MASK 	0x04 
+#define MEMORY_MASK 	0x08
+#define MAC_MASK 	0x10 
+#define PHY_MASK 	0x20
+#define INT_LOOP_MASK 	0x40
+#define EXT_MASK 	0x80
+#define INTERRUPT_MASK 	0x100
+#define SPEED_MASK 	0x200
+#define LOOPBACK_MASK 	0x400
+
 #ifdef DEBUGON
 	#define DEBUG TRUE 
 #else
@@ -106,7 +118,7 @@ struct rule_info {
 	int num_oper; 
 	int sleep; 
 	int threshold; 
-
+	int mask;
 }; 
 
 /****************************************************
@@ -118,7 +130,7 @@ int issue_ioctl(int fd, void  * command , struct htx_data * htx_d);
 
 char * strupr(char * str); 
 
-int update_result(struct ethtool_test *test, int num_tests,  char supported_test[][MSG_TEXT_SIZE], struct self_test * self_test, struct htx_data * htx_d);
+int update_result(struct ethtool_test *test, int num_tests,  char supported_test[][MSG_TEXT_SIZE], int error_mask, struct self_test * self_test, struct htx_data * htx_d);
 
 int dump_test(struct ethtool_test *test, struct ethtool_gstrings *strings);
 

--- a/etc/scripts/htxconf.awk
+++ b/etc/scripts/htxconf.awk
@@ -520,6 +520,7 @@ BEGIN {
 
 
     cmd = "";
+	DIR = snarf("echo $HTX_HOME_DIR");
 
     #Hxediag stanza enabled only on HTX ubuntu Release
 	ip=snarf("hostname -i");
@@ -539,13 +540,20 @@ BEGIN {
 			}
 		}
 		if(found == 0) {
-			cmd1=sprintf("ethtool -i %s | awk -F : ' {print $2}' \n", intface);
-			driver=snarf(cmd1);
-			if(driver ~ /tg3/ || driver ~ /bnx2x/) {
-				mkstanza("hxediag", "Broadcom Ethernet","NIC",intface,"hxediag", "default", "default" );
-			}
-			if(driver ~ /mlx4_en/) {
-				mkstanza("hxediag", "Mellanox RoCE", "NIC",intface,"hxediag", "default", "default" );
+			num_lines = "";
+			cmd1 = sprintf("cat %s/htx_diag.config | wc | awk 'NR==1 {print $1}'", DIR);
+			num_lines = snarf(cmd1);
+			for(count=0; count < num_lines; count++) {
+				command = sprintf("cat %s/htx_diag.config 2> /dev/null | awk -F':' 'NR==%d {print $1}'", DIR, (count+1));
+				driver_name = snarf(command);
+				command = sprintf("cat %s/htx_diag.config 2> /dev/null | awk -F':' 'NR==%d {print $2}'", DIR, (count+1));
+				driver_desc=snarf(command);
+				cmd1=sprintf("ethtool -i %s | awk -F : ' {print $2}' \n", "enP3p3s0f1");
+				driver=snarf(cmd1);
+
+				if(driver ~ driver_name) {
+					mkstanza("hxediag", driver_desc,"NIC",intface,"hxediag", "default", "default" );
+				}
 			}
 		}
 	}

--- a/htx_diag.config
+++ b/htx_diag.config
@@ -1,0 +1,3 @@
+bnx2x:Broadcom Ethernet
+tg3:Broadcom Ethernet
+mlx4_en:Mellanox RoCE

--- a/rules/reg/hxediag/default
+++ b/rules/reg/hxediag/default
@@ -4,16 +4,18 @@ rule_id = DiagTest_Online
 test = online 
 num_oper = 100 
 sleep = 5 
+mask = 0x07FD
 
 ***** Offline test mode 
 rule_id = DiagTest_Offline 
 test = offline
 num_oper = 100
 sleep = 5
+mask = 0x07FD
 
 ***** External loopback test mode 
 rule_id = DiagTest_ExtLb
 test = external_lb 
 num_oper = 100
 sleep = 5
-
+mask = 0x07FD

--- a/rules/reg/hxediag/hxediag.readme
+++ b/rules/reg/hxediag/hxediag.readme
@@ -113,6 +113,7 @@ rule_id = DiagTest_Offline
 test = offline
 num_oper = 100
 sleep = 5
+mask = 0x07FD
 
 1. rule_id - String to uniquely identify each stanza.
 
@@ -123,6 +124,10 @@ sleep = 5
 4. Sleep :  (in seconds) : Controls how many seconds to sleep before executing the same test  again.
 
 5. Threshold : Some of the self test may fail intermittently while they pass on most iterations. Threshold controls percentage of failure testcase when exerciser would report failure and exit. If failure percentage is less than threshold then exerciser would dump fail information in  /tmp/htxmsg and continue.  Default threshold is 50(in percent)
+i
+
+6. Mask : User can modify this field to set the test error status they are interested in. If an error has occured user can either ignore it or get notified by modifying the mask field.
+default value is 0x07FD whilch is 11111111101; each bit field corresponds to particular ethtool supported test in the order (NVRAM, LINK, REGISTER, MEMORY, MAC, PHY, INT_LOOP, Ext, INTERRUPT, SPEED, LOOPBACK). In the default mask value(0x07FD) we are ignoring Link Test error report. 
 
 Exerciser statistics : 
 
@@ -136,6 +141,11 @@ Exerciser uses following fields in /tmp/htxstats to update exerciser specific st
 
 4. good_others  : Number of test passed.
 
+Note: If user would like to test new adapters, they are now allowed to append new drivers which support ethtool infrastructure in file /usr/lpp/htx_diag.config in the format driver_name:desvice_description.
+For example: bnx2x:Broadcom Ethernet
+
+
 Last Updated :
 
 December 8,  2014 by Piyush Sharma(piyusharma@in.ibm.com)
+December 9,  2016 by Shilpa Chandrappa(shchand9@in.ibm.com)


### PR DESCRIPTION
If user would like to test new adapters, they are now allowed to append new drivers which support ethtool infrastructure in file /usr/lpp/htx/htx_diag.config in the format driver_name:desvice_description.
For example: bnx2x:Broadcom Ethernet

Also, users are now allowed to set the mask field in rule file to get notified only on the interested ethtool test report. Users can modify this field to set the test error status they are interested in. If an error has occured user can either ignore it or get notified by modifying the mask field.
default value is 0x07FD whilch is 11111111101; each bit field corresponds to particular ethtool supported test in the order (NVRAM, LINK, REGISTER, MEMORY, MAC, PHY, INT_LOOP, Ext, INTERRUPT, SPEED, LOOPBACK). In the default mask value(0x07FD) we are ignoring Link Test error report.