### PR TITLE
Removing hardcoding of data used in diag stanza creation

### DIFF
--- a/etc/scripts/htxconf.awk
+++ b/etc/scripts/htxconf.awk
@@ -522,7 +522,6 @@ BEGIN {
     cmd = "";
 	DIR = snarf("echo $HTX_HOME_DIR");
 
-    #Hxediag stanza enabled only on HTX ubuntu Release
 	ip=snarf("hostname -i");
 	split(ip, ip_array, " ");
 	for (cnt in ip_array) {
@@ -548,7 +547,7 @@ BEGIN {
 				driver_name = snarf(command);
 				command = sprintf("cat %s/htx_diag.config 2> /dev/null | awk -F':' 'NR==%d {print $2}'", DIR, (count+1));
 				driver_desc=snarf(command);
-				cmd1=sprintf("ethtool -i %s | awk -F : ' {print $2}' \n", "enP3p3s0f1");
+				cmd1=sprintf("ethtool -i %s | awk -F : ' {print $2}' \n", intface);
 				driver=snarf(cmd1);
 
 				if(driver ~ driver_name) {


### PR DESCRIPTION
Removing the hard coded data which was used for internal testing purpose from htxconf.awk file.
Also, removed htxubuntu only comment from htxconf.awk file during diag mdt stanza creation. 