### PR TITLE
Adding revamped htx memory exerciser as part of new nest framework

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -1,6 +1,6 @@
 include ../htx.mk
 
-SUBDIRS= hxssup hxsmsg hxstats htxd hxesamp show_syscfg  hxetlbie \
+SUBDIRS= hxssup hxsmsg hxstats htxd hxesamp show_syscfg  hxetlbie hxecentaur \
 	hxestorage hxecom hxediag hxedapl hxemem64 hxetape hxesctu hxefpu64 hxecd  \
 	hxecache hxerng bufdisp hxeasy hxefabricbus create_eq_cfg create_eq_mdt
 

--- a/bin/hxecache/hxecache.c
+++ b/bin/hxecache/hxecache.c
@@ -3247,7 +3247,11 @@ int setup_cache_thread_context(void) {
 			th_array[index].thread_type 					= CACHE;
 			th_array[index].current_rule					= current_rule;
 			th_array[index].start_class	 					= 0;
-			th_array[index].end_class	   					= (2*cache_asc) - 1;
+            if((system_information.pvr == POWER9_NIMBUS) || (system_information.pvr == POWER9_CUMULUS)) {
+                th_array[index].end_class                   = (cache_asc - 1);
+            }else{
+			    th_array[index].end_class	   				= (2*cache_asc) - 1;
+            }
 			th_array[index].walk_class_jump 				= 1;
 			th_array[index].cache_instance_under_test 		= j;
 			th_array[index].memory_starting_address_offset 	= /*th_array[index].cache_instance_under_test * 2*cache_size*/ 0 ;
@@ -3575,7 +3579,7 @@ int create_cache_threads(void) {
 	int	index			= 0;
 	int	core 			= 0;
 	int num_cores		= system_information.num_cores;
-    int num_cache_threads = current_rule->num_cache_threads_created;
+    int num_cache_threads = current_rule->num_cache_threads_to_create;
     int thd;
 	switch(testcase_type) {
 		case CACHE_BOUNCE_ONLY :

--- a/bin/hxecentaur/Makefile
+++ b/bin/hxecentaur/Makefile
@@ -1,0 +1,37 @@
+include ../../htx.mk
+
+TARGET=hxecentaur
+
+LDFLAGS +=
+
+OBJ_SUFF=.o
+
+vpath= ../hxemem64/
+
+OBJECTS = \
+	hxemem${OBJ_SUFF} \
+	mem_operation${OBJ_SUFF} \
+	rand_operation${OBJ_SUFF} \
+	pat_operation${OBJ_SUFF} \
+	test_L4${OBJ_SUFF} \
+	gen_tlbie${OBJ_SUFF} \
+
+CFLAGS += -D__64_LINUX__ -D_GNU_SOURCE -DKERNEL_2_6 -D_REENTRANT -g -D__HTX_LINUX__ -I./../hxemem64
+ 
+LIBS += -lpthread -lhtx64
+
+.PHONY: all clean
+
+%.o: ../hxemem64/%.c
+	${CC} ${CFLAGS} ${INCLUDES} -c $< -o $@
+
+%.o: ../hxemem64/%.s
+	${AS} -c $< -o $@
+
+all: ${OBJECTS}
+	${CC} ${LDFLAGS} ${LIBPATH} ${OBJECTS} ${LIBS} -o ${TARGET}
+	${CP} ${TARGET} ${SHIPBIN}/${TARGET}
+
+clean:
+	${RM} -rf *.o ${TARGET} ${SHIPBIN}/${TARGET}
+

--- a/bin/hxemem64/Makefile
+++ b/bin/hxemem64/Makefile
@@ -5,12 +5,16 @@ TARGET= hxemem64
 LDFLAGS +=
 
 OBJ_SUFF=.o
-OBJECTS = hxemem${OBJ_SUFF} \
-        mem_operation${OBJ_SUFF} \
-        rand_operation${OBJ_SUFF} \
-        pat_operation${OBJ_SUFF} \
-        test_L4${OBJ_SUFF} \
-        gen_tlbie${OBJ_SUFF}
+OBJECTS =  \
+    nest_framework${OBJ_SUFF} \
+    nest_read_rules${OBJ_SUFF} \
+    parse_filters${OBJ_SUFF} \
+    mem${OBJ_SUFF} \
+    memory_operations${OBJ_SUFF} \
+    mem_pattern_file_operations${OBJ_SUFF} \
+    mem_random_pat_operations${OBJ_SUFF} \
+    stride_operation${OBJ_SUFF}
+
  
 SRCS = $(patsubst %.o, %.c, $(OBJECTS))
 

--- a/bin/hxemem64/hxemem.c
+++ b/bin/hxemem64/hxemem.c
@@ -15,8 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* IBM_PROLOG_END_TAG */
-/* @(#)87       1.74.1.19  src/htx/usr/lpp/htx/bin/hxemem64/hxemem.c, exer_mem64, htx61J, htx61J_639 4/23/10 03:41:33 */
 #include "hxemem64.h"
 #ifndef __HTX_LINUX__
 #include <sys/vminfo.h>

--- a/bin/hxemem64/mem.c
+++ b/bin/hxemem64/mem.c
@@ -1,0 +1,2648 @@
+/* IBM_PROLOG_BEGIN_TAG */
+/*
+ * Copyright 2003,2016 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "nest_framework.h"
+#include <sys/resource.h>
+
+extern char page_size_name[MAX_PAGE_SIZES][8];
+extern struct nest_global g_data;
+int cpu_add_remove_test = 0;
+struct shm_alloc_th_data {
+		int thread_num;
+		int chip_num;
+		int bind_cpu_num;
+		int chip_cpu_num;
+		pthread_t tid;
+}*shm_alloc_th=NULL;
+void SIGRECONFIG_handler (int sig, int code, struct sigcontext *scp);
+int check_ame_enabled(void);
+int check_if_ramfs(void);
+int fill_per_chip_segment_details(void);
+int fill_system_segment_details(void);
+int run_stanza_operation(void);
+int fill_thread_context(void);
+int fill_thread_context_with_filters_disabled(void);
+int log_mem_seg_details(void);
+int create_and_run_thread_operation(void);
+int reset_segment_owners(void);
+int get_shared_memory(void);
+int allocate_buffers(int,int,struct shm_alloc_th_data* );
+int deallocate_buffers(int,int,struct shm_alloc_th_data*);
+int remove_shared_memory(void);
+int fill_affinity_based_thread_structure(struct chip_mem_pool_info*, struct chip_mem_pool_info*,int);
+int do_mem_operation(int);
+int do_rim_operation(int);
+int do_dma_operation(int);
+int get_mem_access_operation(int);
+int dump_miscompared_buffers(int,unsigned long,int,int,unsigned long *,int,int,int,struct segment_detail*);
+void release_thread_resources(int);
+void print_memory_allocation_seg_details(void);
+void* get_shm(void*);
+void* remove_shm(void*);
+void* mem_thread_function(void *);
+int apply_filters(void);
+#ifdef __HTX_LINUX__
+void SIGUSR2_hdl(int, int, struct sigcontext *);
+#endif
+
+struct mem_exer_info mem_g;
+/*op_fptr operation_fun_typ[MAX_PATTERN_TYPES][MAX_MEM_ACCESS]= {
+    {&mem_operation_write_dword,&mem_operation_write_word,&mem_operation_write_byte,&mem_operation_read_dword,
+            &mem_operation_read_word,&mem_operation_read_byte,&mem_operation_comp_dword,\
+            &mem_operation_comp_word,&mem_operation_comp_byte,NULL,NULL,NULL,NULL,NULL},
+    {&mem_operation_write_dword,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
+    {&mem_operation_write_addr,NULL,NULL,NULL,NULL,NULL,&mem_operation_comp_addr,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
+    {&mem_operation_write_dword,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL}
+};*/
+
+op_fptr operation_fun_typ[MAX_PATTERN_TYPES][MAX_OPER_TYPES][MAX_MEM_ACCESS_TYPES]= 
+{
+    {
+        {&mem_operation_write_dword,&mem_operation_write_word,&mem_operation_write_byte},
+        {&mem_operation_read_dword,&mem_operation_read_word,&mem_operation_read_byte},
+        {&mem_operation_comp_dword,&mem_operation_comp_word,&mem_operation_comp_byte},
+        {&mem_operation_rim_dword,&mem_operation_rim_word,&mem_operation_rim_byte}
+    },
+    {
+        {&pat_operation_write_dword,&pat_operation_write_word,&pat_operation_write_byte},
+        {&mem_operation_read_dword,&mem_operation_read_word,&mem_operation_read_byte},
+        {&pat_operation_comp_dword,&pat_operation_comp_word,&pat_operation_comp_byte},
+        {&pat_operation_rim_dword,&pat_operation_rim_word,&pat_operation_rim_byte}
+    },
+    {
+        {&mem_operation_write_addr,NULL,NULL},
+        {&mem_operation_read_dword,NULL,NULL},
+        {&mem_operation_comp_addr,NULL,NULL},
+        {&mem_operation_write_addr_comp,NULL,NULL}
+    },
+    {
+        {&rand_operation_write_dword,&rand_operation_write_word,&rand_operation_write_byte},
+        {&mem_operation_read_dword,&mem_operation_read_word,&mem_operation_read_byte},
+        {&rand_operation_comp_dword,&rand_operation_comp_word,&rand_operation_comp_byte},
+        {&rand_operation_rim_dword,&rand_operation_rim_word,&rand_operation_rim_byte}
+    }
+};
+int mem_exer_opearation(){
+	int rc,previous_stanza_threads=0;
+
+    mem_g.shm_cleanup_done = 0;
+    rc = atexit(remove_shared_memory);
+    if(rc != 0) {
+        displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"[%d] Error: Could not register for atexit!\n",__LINE__);
+        return ( rc );
+    }
+
+#ifndef __HTX_LINUX__
+    /*Register SIGRECONFIG handler */
+    g_data.sigvector.sa_handler = (void (*)(int)) SIGRECONFIG_handler;
+    sigaction(SIGRECONFIG, &g_data.sigvector, (struct sigaction *) NULL);
+#endif
+	/* update global pointer */
+	g_data.test_type_ptr = (struct mem_test_info*)&mem_g;
+
+	/* If cpus are in dedicated mode, disable cpu/mem filter usage, instaed use full system mem view*/
+	if(g_data.sys_details.shared_proc_mode == 1){
+		displaym(HTX_HE_INFO,DBG_MUST_PRINT,"shared proc mode detected,disabling cpu/mem filter usage\n");
+		g_data.gstanza.global_disable_filters = 1;
+	}	
+	/* Check if AME is enabled on system */
+#ifndef __HTX_LINUX__
+    rc =  check_ame_enabled();    
+    if(rc != SUCCESS){
+        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:check_ame_enabled()failed wit rc = %d\n",
+            __LINE__,__FUNCTION__,rc);
+        return (FAILURE);
+    }
+#endif
+
+	/* Checking if filesystem is on RAM if yes dma_flag would be set */
+    rc = check_if_ramfs();
+	if(rc != SUCCESS){
+		displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:check_if_ramfs() failed with rc = %d\n",__LINE__,__FUNCTION__,rc);
+		return(FAILURE);
+	}
+	rc = fill_exer_huge_page_requirement();
+	if(rc != SUCCESS){
+		displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:fill_exer_huge_page_requirement() failed wit rc = %d\n",
+			__LINE__,__FUNCTION__,rc);	
+		return (FAILURE);
+	}
+    if (g_data.exit_flag == 1) {
+        exit(1);
+    }
+
+    mem_g.total_segments = 0;/*initialize overall segments count to 0*/
+	if(g_data.gstanza.global_disable_filters == 1){
+		/* consider % of whole memory and fill segment details for all supported page size pools*/
+		rc = fill_system_segment_details();
+		if  ( rc != SUCCESS){
+			displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:fill_system__segment_details() failed with rc = %d\n",__LINE__,__FUNCTION__,rc);
+			return (FAILURE);
+		}
+    	displaym(HTX_HE_INFO,DBG_MUST_PRINT,"Due to system configuration,Memory Exercising will happen at System level memory,\n"
+            "Total threads to be created to get shared memory =%d\n",g_data.gstanza.global_num_threads);
+	}else{
+	/* consider % of per chip memory and fill segment details for all supported page size pools*/
+		rc = fill_per_chip_segment_details();
+		if  ( rc != SUCCESS){
+			displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:fill_per_chip_segment_details() failed with rc = %d\n",__LINE__,__FUNCTION__,rc);
+			return (FAILURE);
+		}
+		/* consider strict local affinity to allocate memory*/
+		#ifndef __HTX_LINUX__
+		rc = system("vmo -o enhanced_affinity_vmpool_limit=-1");    
+		if(rc < 0){
+			displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"vmo -o enhanced_affinity_vmpool_limit=-1"
+			"failed errno %d rc = %d\n",errno,rc);
+			return(FAILURE);
+		}
+		displaym(HTX_HE_INFO,DBG_IMP_PRINT,"vmo -o enhanced_affinity_vmpool_limit=-1 rc = %d,errno =%d\n",rc,errno);
+        #endif
+    	displaym(HTX_HE_INFO,DBG_MUST_PRINT,"Total threads to be created to get shared memory =%d\n",g_data.sys_details.tot_cpus);
+	}
+	#ifdef __HTX_LINUX__
+    rc = modify_shared_mem_limits_linux(mem_g.total_segments);
+    if  ( rc != SUCCESS){
+        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:modify_shared_mem_limits_linux() failed with rc = %d\n",__LINE__,__FUNCTION__,rc);
+        return (FAILURE);
+    }
+	#endif
+    int current_priority = getpriority(PRIO_PROCESS,g_data.pid);
+    if(current_priority == -1){
+        displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"[%d]%s:getpriority() failed with %d, errno:%d(%s)\n",
+            __LINE__,__FUNCTION__,current_priority,errno,strerror(errno));
+    }
+    rc = setpriority(PRIO_PROCESS,g_data.pid,10);
+    if(rc == -1){
+        displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"[%d]%s:setpriority() failed with %d, errno:%d(%s)\n",
+            __LINE__,__FUNCTION__,rc,errno,strerror(errno));
+    }
+    print_memory_allocation_seg_details();
+	/*create shared memories by spawning multiple threads*/
+	rc = get_shared_memory();
+	if(rc != SUCCESS) {
+		displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:get_shared_memory() failed with rc = %d",__LINE__,__FUNCTION__,rc);
+		return (rc);
+	}
+    if (g_data.exit_flag == 1) {
+        remove_shared_memory();
+        exit(1);
+    }
+
+    if(current_priority != -1){
+        rc = setpriority(PRIO_PROCESS,g_data.pid,current_priority);
+        if(rc == -1){
+            displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"[%d]%s:setpriority() failed with %d, errno:%d(%s)\n",
+                 __LINE__,__FUNCTION__,rc,errno,strerror(errno));
+        }
+    }
+	displaym(HTX_HE_INFO,DBG_MUST_PRINT,"segment details logged into %s/mem_segment_details\n",g_data.htx_d.htx_exer_log_dir);
+	do {
+		STATS_VAR_INIT(test_id, 0)
+		g_data.stanza_ptr = &g_data.stanza[0];
+
+		while( strcmp(g_data.stanza_ptr->rule_id,"NONE") != 0)
+		{
+            if(cpu_add_remove_test == 1){
+                g_data.stanza_ptr->disable_cpu_bind = 1;
+            }
+			rc = apply_filters();
+			if(rc != SUCCESS) {
+				displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:apply_filters() failed with rc = %d",__LINE__,__FUNCTION__,rc);
+				remove_shared_memory();
+				return (rc);
+			}
+            /*RV7: do profile below fun,compare print enabled and disabled performance*/
+            /*if(previous_stanza_threads != g_data.stanza_ptr->num_threads){*/
+                print_memory_allocation_seg_details();
+                displaym(HTX_HE_INFO,DBG_MUST_PRINT,"Total threads to be created = %d\n",g_data.stanza_ptr->num_threads);
+            /*}*/
+            mem_g.affinity = g_data.stanza_ptr->affinity;
+#if 0
+            /* If mem_DR_done flag is set then mem device will goes to DT */
+            if(g_data.mem_DR_flag){
+                STATS_HTX_UPDATE(RECONFIG);
+                g_data.mem_DR_flag= 0;
+                remove_shared_memory();
+                exit(0);
+            }
+#endif
+            rc = run_stanza_operation();
+            if(rc != SUCCESS){
+                remove_shared_memory();
+                exit(0);
+            }
+            if (g_data.exit_flag == 1) {
+                remove_shared_memory();
+                exit(1);
+            }
+            previous_stanza_threads=g_data.stanza_ptr->num_threads;
+            g_data.stanza_ptr++;
+        }
+		STATS_HTX_UPDATE(FINISH);
+	/*	if ((read_rules()) < 0 ) {
+            remove_shared_memory();
+			exit(1);
+		}*/
+        if (g_data.exit_flag == 1) {
+            remove_shared_memory();
+            return(FAILURE);
+        } /* endif */
+	}while (g_data.standalone != 1); /* while run type is not standalone (OTH) */
+
+	rc = remove_shared_memory();
+	if(rc != SUCCESS) {
+		displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:remove_shared_memory()failed with rc = %d",__LINE__,__FUNCTION__,rc);
+	}
+	return(SUCCESS);
+}
+
+/**************************************************************************************
+*run_stanza_operation: calls specific test case per stanza as specified in rule file*
+***************************************************************************************/
+int run_stanza_operation(){
+	int rc=SUCCESS;
+    int prev_debug_level = g_data.gstanza.global_debug_level;
+
+	/* Set the debug level to the debug level specified in this stanza */
+	if (g_data.stanza_ptr->debug_level) {
+		g_data.gstanza.global_debug_level = g_data.stanza_ptr->debug_level;
+	}
+
+    rc = fill_thread_context();
+    if(rc != SUCCESS){
+        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s: fill_thread_context() failed with rc = %d\n",__LINE__,__FUNCTION__,rc);
+        return(FAILURE);
+    }
+
+    rc = log_mem_seg_details();
+    if(rc != SUCCESS){
+            displaym(HTX_HE_INFO,DBG_MUST_PRINT,"log_mem_seg_details() returned rc =%d\n",rc);
+        }
+
+        g_data.htx_d.test_id++;
+        hxfupdate(UPDATE,&g_data.htx_d);
+
+        rc = create_and_run_thread_operation();
+        if(rc != SUCCESS){
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s: create_and_run_thread_operation() failed with rc = %d\n",__LINE__,__FUNCTION__,rc);
+            return(FAILURE);
+        }
+
+
+        g_data.gstanza.global_debug_level = prev_debug_level;	
+        if(g_data.thread_ptr != NULL){
+            free(g_data.thread_ptr);
+        }
+        if(mem_g.mem_th_data != NULL){
+            free(mem_g.mem_th_data);
+        }
+        return(SUCCESS);
+    }
+
+    int fill_system_segment_details(){
+        int pi;
+        unsigned long used_mem=0,std_seg_size,rem_seg_size=0;
+        struct page_wise_seg_info *sys_seg_details;
+        struct mem_info* sys_memptr = &g_data.sys_details.memory_details;
+        unsigned int num_segs=0,fixed_size_num_segs=0,seg,k;
+        #ifdef  __HTX_LINUX__
+        long long hard_limt_mem_size = DEF_SEG_SZ_4K * (32 * KB); /* Linux has a hard limit of 32K for total number of shms (SHMNI)*/
+        unsigned long new_seg_size       = sys_memptr->total_mem_avail/(32 * KB);
+        #endif
+        int total_cpus ;
+        if( g_data.gstanza.global_num_threads > 0){
+            total_cpus = g_data.gstanza.global_num_threads;
+        }else{
+            total_cpus = g_data.sys_details.tot_cpus;
+            g_data.gstanza.global_num_threads = total_cpus;
+        }
+
+        for(pi = 0;pi<MAX_PAGE_SIZES;pi++){
+            if((sys_memptr->pdata[pi].supported == TRUE) && (sys_memptr->pdata[pi].free != 0)){
+                if (pi < PAGE_INDEX_16G) {
+                    if(g_data.gstanza.global_alloc_segment_size == -1){
+                        std_seg_size = DEF_SEG_SZ_4K; /* 256MB for < 16G */
+                    }else{	
+                        if(g_data.gstanza.global_alloc_segment_size >= sys_memptr->pdata[pi].free){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:alloc_segment_size parameter in rule file %d given value %ld (page:%s)more than %llu"
+                                " avialable in system, Either remove 'alloc_segment_size' or set to smaller value.\n",__LINE__,__FUNCTION__,g_data.rules_file_name,
+                                g_data.gstanza.global_alloc_segment_size,page_size_name[pi],sys_memptr->pdata[pi].free);
+                            return(FAILURE);
+                        }
+                        std_seg_size = g_data.gstanza.global_alloc_segment_size;
+                        #ifdef  __HTX_LINUX__
+                        if((sys_memptr->total_mem_avail/std_seg_size) >= 32 * KB){
+                            std_seg_size = DEF_SEG_SZ_4K;
+                            g_data.gstanza.global_alloc_segment_size= DEF_SEG_SZ_4K;
+                            displaym(HTX_HE_INFO,DBG_MUST_PRINT,"Overwriting rule file defined segment size to %lu,"
+                                " due to linux hardlimit(32K) on num segments per process\n",std_seg_size);
+                        }
+                        #endif
+                    }
+                    #ifdef  __HTX_LINUX__
+                    if ((sys_memptr->total_mem_avail > hard_limt_mem_size) && (std_seg_size < new_seg_size)) {
+                         displaym(HTX_HE_INFO,DBG_MUST_PRINT,"setting standard segment size to %lu, due to linux hardlimit(32K) on num segments/process\n",new_seg_size);
+                        std_seg_size = new_seg_size;
+                     }
+                    #endif
+                }else{
+                    std_seg_size = DEF_SEG_SZ_16G; /* 1 16GB page */
+                }
+                if (pi < PAGE_INDEX_2M){
+                    if(g_data.gstanza.global_alloc_mem_size> 0){/* if alloc_mem_size is configured then we ignore alloc_mem_percent*/
+                        used_mem = g_data.gstanza.global_alloc_mem_size;
+                        if(used_mem < sys_memptr->pdata[pi].psize){
+                            used_mem = sys_memptr->pdata[pi].psize;
+                        }
+                        g_data.gstanza.global_alloc_mem_percent= (used_mem / sys_memptr->pdata[pi].free) * 100;
+                    }else{
+                        used_mem    = (g_data.gstanza.global_alloc_mem_percent/100.0) * sys_memptr->pdata[pi].free;
+						if(g_data.gstanza.global_alloc_mem_percent == 0){
+							continue;
+						}
+                    }
+                }else{
+                    used_mem    = sys_memptr->pdata[pi].free;
+                }
+                used_mem = (used_mem/sys_memptr->pdata[pi].psize);
+                used_mem = (used_mem * sys_memptr->pdata[pi].psize);
+
+                if((used_mem/total_cpus) < std_seg_size){
+					if(used_mem != 0){
+                    	num_segs = total_cpus;
+					}
+                    fixed_size_num_segs=num_segs;
+                    rem_seg_size = 0;
+                }else {
+                    num_segs      =  (used_mem/std_seg_size);
+                    rem_seg_size  = (used_mem%std_seg_size);
+                    fixed_size_num_segs=num_segs;
+                    if(rem_seg_size > 0){
+                        num_segs++;
+                        rem_seg_size = rem_seg_size/sys_memptr->pdata[pi].psize;
+                        rem_seg_size = rem_seg_size * sys_memptr->pdata[pi].psize;
+                    }
+                }
+                /* Allocate malloc memory to hold segment management details for every page pool from whole system mem*/
+                sys_memptr->pdata[pi].page_wise_seg_data = (struct page_wise_seg_info*)malloc(num_segs * sizeof(struct page_wise_seg_info));
+                if(sys_memptr->pdata[pi].page_wise_seg_data == NULL){
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:malloc failed with errno:%d(%s)for size=%llu\n",
+                         __LINE__,__FUNCTION__,errno,strerror(errno),num_segs * sizeof(struct page_wise_seg_info));
+                    return(FAILURE);
+                }
+
+                sys_memptr->pdata[pi].num_of_segments 		 =  num_segs;
+                sys_seg_details = sys_memptr->pdata[pi].page_wise_seg_data;
+                for(seg=0; seg<fixed_size_num_segs; seg++){
+                    if((used_mem/total_cpus) < std_seg_size){/*If memory (huge pages specially) falls to be less than 256M,adjust segment size to num of threads*/
+                        sys_seg_details[seg].shm_size = (used_mem/total_cpus);
+                        if((sys_seg_details[seg].shm_size%sys_memptr->pdata[pi].psize)){
+                            sys_seg_details[seg].shm_size = sys_seg_details[seg].shm_size/sys_memptr->pdata[pi].psize;
+                            sys_seg_details[seg].shm_size = sys_seg_details[seg].shm_size * sys_memptr->pdata[pi].psize;
+                        }
+                    }else{
+                        sys_seg_details[seg].shm_size=std_seg_size;
+                    }
+                    sys_seg_details[seg].seg_num   =   seg;
+                    sys_seg_details[seg].original_shm_size = sys_seg_details[seg].shm_size;	
+                }
+                    /*
+                    * Preserve value of seg from above loop
+                    * in case another segment of smaller size is possible
+                    */
+                if (rem_seg_size > 0){
+                    sys_seg_details[seg].shm_size = rem_seg_size;
+                    sys_seg_details[seg].original_shm_size = rem_seg_size;
+                    sys_seg_details[seg].seg_num   =   seg;
+                }			
+                for(k=0;k<num_segs;k++){
+                    sys_seg_details[k].shm_mem_ptr = NULL;
+                    sys_seg_details[k].shmid       = -1;
+                    debug(HTX_HE_INFO,DBG_DEBUG_PRINT," seg_num=%d:shm sizes[%u] = %lu (%s pages:%lu)\n",
+                        sys_seg_details[k].seg_num,k,sys_seg_details[k].shm_size,page_size_name[pi],
+                        (sys_seg_details[k].shm_size/sys_memptr->pdata[pi].psize));
+                }
+            }
+            mem_g.total_segments += sys_memptr->pdata[pi].num_of_segments;
+        }
+        return (SUCCESS);
+    }
+    /************************************************************************************
+    *Alocates shared memory segments for all supported page size pools.
+    *considering 90% of system avialable memory(per chip),divide page wise segemnts	among threads to allocate memory.						
+    ************************************************************************************/
+
+    int fill_per_chip_segment_details(){
+
+        int pi,n,count=0;
+        unsigned long used_mem=0,std_seg_size,rem_seg_size=0;
+        struct page_wise_seg_info *seg_details;
+        struct mem_info* memptr = &g_data.sys_details.memory_details;
+        unsigned int num_segs=0,fixed_size_num_segs=0,seg,k;
+        int num_of_chips = g_data.sys_details.num_chip_mem_pools;
+        struct chip_mem_pool_info* mem_details_per_chip  = &g_data.sys_details.chip_mem_pool_data[0];
+    #ifdef  __HTX_LINUX__
+        long long hard_limt_mem_size = DEF_SEG_SZ_4K * (32 * KB); /* Linux has a hard limit of 32K for total number of shms (SHMNI)*/
+        unsigned long new_seg_size       = memptr->total_mem_avail/(32 * KB);
+    #else 
+        float percent_factor = 0.0;
+    #endif
+
+        /* In Linux use whichever supported base page(currently either 4k or 64k)*/
+        for(n = 0; n < num_of_chips; n++){
+            if(g_data.gstanza.global_alloc_huge_page == 0){
+                mem_details_per_chip[n].memory_details.pdata[PAGE_INDEX_2M].supported = FALSE;
+                mem_details_per_chip[n].memory_details.pdata[PAGE_INDEX_16M].supported = FALSE;
+                mem_details_per_chip[n].memory_details.pdata[PAGE_INDEX_16G].supported = FALSE;
+            }
+            if(!mem_details_per_chip[n].has_cpu_and_mem){
+                displaym(HTX_HE_INFO,DBG_MUST_PRINT,"[%d]%s:chip %d either does not have memory or cpu behind it" \
+                        " free mem = %llu and total cpus = %d\n",__LINE__,__FUNCTION__,n,mem_details_per_chip[n].memory_details.total_mem_free,mem_details_per_chip[n].num_cpus);
+                    count++;
+                    continue;
+            }
+            for(pi = 0;pi<MAX_PAGE_SIZES;pi++){
+                if((mem_details_per_chip[n].memory_details.pdata[pi].supported == TRUE) && (mem_details_per_chip[n].memory_details.pdata[pi].free != 0)) {
+                    if (pi < PAGE_INDEX_16G) {
+                        if(g_data.gstanza.global_alloc_segment_size== -1){
+                            std_seg_size = DEF_SEG_SZ_4K; /* 256MB for < 16G */
+                        }else{
+                            if(g_data.gstanza.global_alloc_segment_size >=  mem_details_per_chip[n].memory_details.pdata[pi].free){
+                                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:global_alloc_segment_size parameter in rule file %s given value %ld (page:%s)more than %llu for chip %d\n"
+                                    "Either remove 'global_alloc_segment_size' or set to smaller value.\n",__LINE__,__FUNCTION__,g_data.rules_file_name,
+                                    g_data.gstanza.global_alloc_segment_size,page_size_name[pi], mem_details_per_chip[n].memory_details.pdata[pi].free,n);
+                                return (FAILURE);
+                            }
+                            std_seg_size = g_data.gstanza.global_alloc_segment_size;
+                            #ifdef  __HTX_LINUX__
+                            if((memptr->total_mem_avail/std_seg_size) >= 32 * KB){
+                                std_seg_size = DEF_SEG_SZ_4K;
+                                g_data.gstanza.global_alloc_segment_size= DEF_SEG_SZ_4K;
+                                displaym(HTX_HE_INFO,DBG_MUST_PRINT,"Overwriting rule file defined segment size to %lu,"
+                                    " due to linux hardlimit(32K) on num segments per process\n",std_seg_size);
+                            }
+                            #endif
+                        }
+    #ifdef  __HTX_LINUX__
+                        if ((memptr->total_mem_avail > hard_limt_mem_size) && (std_seg_size < new_seg_size)) {
+                            displaym(HTX_HE_INFO,DBG_MUST_PRINT,"setting standard segment size to %lu, due to linux hardlimit(32K) on num segments/process\n",new_seg_size);
+                            std_seg_size = new_seg_size;
+                        }
+    #endif
+                    }else {
+                        std_seg_size = DEF_SEG_SZ_16G; /* 1 16GB page */
+                    }	
+                    if (pi < PAGE_INDEX_2M){
+                        if(g_data.gstanza.global_alloc_mem_size > 0){/* if alloc_mem_size is configured then we ignore alloc_mem_percent*/
+                            used_mem = g_data.gstanza.global_alloc_mem_size;
+                            if(used_mem < mem_details_per_chip[n].memory_details.pdata[pi].psize){
+                                used_mem = mem_details_per_chip[n].memory_details.pdata[pi].psize;
+                            }
+                            g_data.gstanza.global_alloc_mem_percent= (used_mem / mem_details_per_chip[n].memory_details.pdata[pi].free) * 100;
+                        }else{
+                            used_mem	= (g_data.gstanza.global_alloc_mem_percent/100.0) * mem_details_per_chip[n].memory_details.pdata[pi].free;
+							if(g_data.gstanza.global_alloc_mem_percent == 0){
+								continue;
+							}
+                        }
+                    }else{
+                        used_mem    = mem_details_per_chip[n].memory_details.pdata[pi].free;
+                    }
+                    used_mem = (used_mem/mem_details_per_chip[n].memory_details.pdata[pi].psize);
+                    used_mem = (used_mem*mem_details_per_chip[n].memory_details.pdata[pi].psize);
+
+                    if((used_mem/mem_details_per_chip[n].num_cpus) < std_seg_size){
+                        num_segs = mem_details_per_chip[n].num_cpus;
+						/* Below check is added because on certain system per chip 16M pages found to be less than num cpus in that chip*/
+						if((used_mem/mem_details_per_chip[n].num_cpus) < mem_details_per_chip[n].memory_details.pdata[pi].psize){
+							num_segs = (used_mem / mem_details_per_chip[n].memory_details.pdata[pi].psize);
+						}
+                        fixed_size_num_segs=num_segs;
+                        rem_seg_size = 0;
+                    }else {
+                        num_segs      =  (used_mem/std_seg_size);
+                        rem_seg_size  = (used_mem%std_seg_size);
+                        fixed_size_num_segs=num_segs;
+                        if(rem_seg_size > 0){
+                            num_segs++;
+                            rem_seg_size = rem_seg_size/mem_details_per_chip[n].memory_details.pdata[pi].psize;
+                            rem_seg_size = rem_seg_size * mem_details_per_chip[n].memory_details.pdata[pi].psize;
+                        }
+                    }
+                    /* Allocate malloc memory to hold segment management details for every page pool per chip*/
+                    mem_details_per_chip[n].memory_details.pdata[pi].page_wise_seg_data = (struct page_wise_seg_info*)malloc(num_segs * sizeof(struct page_wise_seg_info));
+                    if(mem_details_per_chip[n].memory_details.pdata[pi].page_wise_seg_data == NULL){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:malloc failed with errno:%d(%s)for size=%llu\n",
+                            __LINE__,__FUNCTION__,errno,strerror(errno),num_segs * sizeof(struct page_wise_seg_info));
+                        return(FAILURE);
+                    }
+                    mem_details_per_chip[n].memory_details.pdata[pi].num_of_segments =  num_segs;
+                    seg_details = mem_details_per_chip[n].memory_details.pdata[pi].page_wise_seg_data;
+                    for(seg=0; seg<fixed_size_num_segs; seg++){
+                        if((used_mem/mem_details_per_chip[n].num_cpus) < std_seg_size){/*If memory (huge pages specially) falls to be less than 256M,adjust segment size to num of threads*/
+                            seg_details[seg].shm_size = (used_mem/mem_details_per_chip[n].num_cpus);
+							if(seg_details[seg].shm_size < mem_details_per_chip[n].memory_details.pdata[pi].psize){
+								seg_details[seg].shm_size = mem_details_per_chip[n].memory_details.pdata[pi].psize;
+							}
+                            if((seg_details[seg].shm_size%mem_details_per_chip[n].memory_details.pdata[pi].psize)){
+                                seg_details[seg].shm_size = seg_details[seg].shm_size/mem_details_per_chip[n].memory_details.pdata[pi].psize;
+                                seg_details[seg].shm_size = seg_details[seg].shm_size*mem_details_per_chip[n].memory_details.pdata[pi].psize;
+                            }
+                        }else{
+                                seg_details[seg].shm_size=std_seg_size;
+                        }
+                        seg_details[seg].seg_num   =   seg;
+                        seg_details[seg].original_shm_size = seg_details[seg].shm_size;
+                    }
+                    /*
+                    * Preserve value of seg from above loop
+                    * in case another segment of smaller size is possible
+                    */
+
+                    if (rem_seg_size > 0){
+                        seg_details[seg].shm_size=rem_seg_size;
+                        seg_details[seg].original_shm_size=rem_seg_size;
+                        seg_details[seg].seg_num = seg;
+                    }
+                    for(k=0;k<num_segs;k++){
+                        seg_details[k].shm_mem_ptr = NULL;
+                        seg_details[k].shmid      = -1;
+                        debug(HTX_HE_INFO,DBG_DEBUG_PRINT," seg_num=%d:shm sizes[%u] = %lu (%s pages:%lu)\n",
+                            seg_details[k].seg_num,k,seg_details[k].shm_size,page_size_name[pi],
+                            (seg_details[k].shm_size/mem_details_per_chip[n].memory_details.pdata[pi].psize));
+                    }
+                }
+                mem_g.total_segments += mem_details_per_chip[n].memory_details.pdata[pi].num_of_segments;
+            }
+            if(count == num_of_chips){
+                debug(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s:system configuration does't seems to be good, few chips have only cpus and few have only" 
+                    "memory, count=%d, num_of_chips=%d\n",__LINE__,__FUNCTION__,count,num_of_chips);
+                print_partition_config();
+                return (FAILURE);
+            }
+        }
+        return (SUCCESS);
+    }
+    /*********************************************************************************************
+    * get_shared_memory(pi),spawn threads equal to cpus per chip to create shared memory segments 
+    * for all supported page size pols
+    *********************************************************************************************/
+    int get_shared_memory(){
+        int ti,n,rc,nchips;
+        struct chip_mem_pool_info* mem_details_per_chip  = &g_data.sys_details.chip_mem_pool_data[0];
+        int tot_sys_threads = g_data.sys_details.tot_cpus;
+        int cpus_track=0; 
+            
+        shm_alloc_th = (struct shm_alloc_th_data*) malloc(sizeof( struct shm_alloc_th_data) * tot_sys_threads);
+        if(shm_alloc_th == NULL){
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s():malloc failed for thread_mem_alloc_data for with errno:%d(%s)size=%llu\n",
+                __LINE__,__FUNCTION__,errno,strerror(errno),(sizeof(struct shm_alloc_th_data) * tot_sys_threads));
+            return(FAILURE); 
+        }	
+        
+        if(g_data.gstanza.global_disable_filters == 0){
+            nchips = g_data.sys_details.num_chip_mem_pools;	
+            for(n=0;n<nchips;n++){
+                if(!mem_details_per_chip[n].has_cpu_and_mem){
+                    displaym(HTX_HE_INFO,DBG_MUST_PRINT,"[%d]%s:chip%d either does not have memory or cpu behind it" \
+                            " free mem = %llu and total cpus = %d\n",__LINE__,__FUNCTION__,n,
+                            mem_details_per_chip[n].memory_details.total_mem_free,mem_details_per_chip[n].num_cpus);
+                    cpus_track  += mem_details_per_chip[n].num_cpus;
+                    continue;
+                }
+                for(ti=0;ti<mem_details_per_chip[n].num_cpus;ti++){
+                    shm_alloc_th[cpus_track+ti].thread_num = (cpus_track+ti);
+                    shm_alloc_th[cpus_track+ti].chip_num   = n;
+                    shm_alloc_th[cpus_track+ti].bind_cpu_num   = mem_details_per_chip[n].cpulist[ti];
+                    shm_alloc_th[cpus_track+ti].chip_cpu_num = ti;
+                    shm_alloc_th[cpus_track+ti].tid 	 = -1;
+                     debug(HTX_HE_INFO,DBG_IMP_PRINT,"Creating thread %d to allocate memory by cpu = %d from chip %d\n",(cpus_track+ti),shm_alloc_th[cpus_track+ti].bind_cpu_num,n); 
+                    rc = pthread_create((pthread_t *)&(shm_alloc_th[cpus_track+ti].tid),NULL, get_shm,(void *)&(shm_alloc_th[cpus_track+ti]));
+                    /*printf("##########Pthread_create : cpus_track=%d, ti=%d, tid=%llx\n",  cpus_track, ti, shm_alloc_th[cpus_track+ti].tid);*/
+                    if ( rc != 0){
+                        displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s:pthread_create failed rc = %d and errno = %d(%s) for thread %d\n",
+                                __LINE__,__FUNCTION__,rc,errno,strerror(errno),cpus_track+ti);
+                        return (FAILURE);
+                    }
+
+                }
+                cpus_track  += mem_details_per_chip[n].num_cpus;
+                if (g_data.exit_flag == 1) {
+                    remove_shared_memory();
+                    exit(1);
+                }
+            }
+            cpus_track=0;	
+            for(n=0;n<nchips;n++){
+                if(!mem_details_per_chip[n].has_cpu_and_mem){
+                    cpus_track  += mem_details_per_chip[n].num_cpus;
+                    continue;
+                }
+                for(ti=0;ti<mem_details_per_chip[n].num_cpus;ti++){
+                    /*printf("********Joining th. cpus_track=%d, ti=%d, tid=%llx\n", cpus_track, ti, shm_alloc_th[cpus_track+ti].tid);*/
+                    rc = pthread_join(shm_alloc_th[cpus_track+ti].tid,NULL);
+                    if(rc != 0) {
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:pthread_join failed rc = %d and errno = %d(%s)for thread %d\n",
+                            __LINE__,__FUNCTION__,rc,errno,strerror(errno),cpus_track+ti);
+                        return (FAILURE);
+                    }
+                    else {
+                        /* debug(HTX_HE_INFO,DBG_DEBUG_PRINT," Thread %d  joined successfully after shm allocation\n",cpus_track+ti); */
+                        shm_alloc_th[cpus_track+ti].tid          = -1;
+                    }
+                }
+                cpus_track	+= mem_details_per_chip[n].num_cpus;
+                        
+                if (g_data.exit_flag == 1) {
+                    remove_shared_memory();
+                    exit(1);
+                }
+            }
+            displaym(HTX_HE_INFO,DBG_DEBUG_PRINT,"\n********Shared Memory allocation Completed for CHIP: %d ***************************\n",n);
+        }else {
+            tot_sys_threads = g_data.gstanza.global_num_threads;
+            for(ti=0;ti<tot_sys_threads;ti++){
+                shm_alloc_th[ti].thread_num = ti;
+                shm_alloc_th[ti].chip_num   = -1;
+                shm_alloc_th[ti].bind_cpu_num = ti;
+                shm_alloc_th[ti].tid = -1;
+                debug(HTX_HE_INFO,DBG_IMP_PRINT,"Creating thread %d to allocate memory by cpu = %d\n",ti,shm_alloc_th[ti].bind_cpu_num);
+                rc = pthread_create((pthread_t *)&(shm_alloc_th[ti].tid),NULL, get_shm,(void *)&(shm_alloc_th[ti]));
+                if(rc != 0){
+                    displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s:pthread_create failed rc = %d and errno = %d(%s) for thread %d\n",
+                            __LINE__,__FUNCTION__,rc,errno,strerror(errno),ti);
+                    return (FAILURE);
+                }
+            }
+            if (g_data.exit_flag == 1) {
+                remove_shared_memory();
+                exit(1);
+            }
+        
+            for(ti=0;ti<tot_sys_threads;ti++){
+               rc = pthread_join(shm_alloc_th[ti].tid,NULL);
+                if(rc != 0) {
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:pthread_join failed rc = %d and errno = %d(%s)for thread %d\n",
+                        __LINE__,__FUNCTION__,rc,errno,strerror(errno),ti);
+                    return (FAILURE);
+                }
+                else {
+                    /* debug(HTX_HE_INFO,DBG_DEBUG_PRINT," Thread %d  joined successfully after shm allocation\n",ti); */
+                    shm_alloc_th[ti].tid          = -1;
+                }
+            }
+
+            if (g_data.exit_flag == 1) {
+                remove_shared_memory();
+                exit(1);
+            }
+        }	
+        return(SUCCESS);
+    }
+
+    int remove_shared_memory(){
+
+        int n,ti,rc,pi;
+        int nchips = g_data.sys_details.num_chip_mem_pools,cpus_track=0;
+        int tot_sys_threads = g_data.sys_details.tot_cpus;
+        struct chip_mem_pool_info* mem_details_per_chip  = &g_data.sys_details.chip_mem_pool_data[0];
+        if(shm_alloc_th == NULL){
+            return SUCCESS;
+        }
+        if(g_data.gstanza.global_disable_filters == 0){
+            for(n=0;n<nchips;n++){
+                if(!mem_details_per_chip[n].has_cpu_and_mem){
+                    cpus_track  += mem_details_per_chip[n].num_cpus;
+                    continue;
+                }
+                for(ti=0;ti<mem_details_per_chip[n].num_cpus;ti++){
+                    debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"Creating thread %d to deallocate memory \n",ti);
+                    rc = pthread_create((pthread_t *)&shm_alloc_th[cpus_track+ti].tid,NULL,remove_shm,(void *)&shm_alloc_th[cpus_track+ti]);
+                    if(rc !=0 ){
+                        displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s:pthread_create failed rc = %d and errno = %d(%s)\n",__LINE__,__FUNCTION__,rc,errno,strerror(errno));
+                        return (FAILURE);
+                    }	
+                }
+                cpus_track      += mem_details_per_chip[n].num_cpus;
+            }
+            cpus_track = 0;
+            for(n=0;n<nchips;n++){
+                if(!mem_details_per_chip[n].has_cpu_and_mem){
+                    cpus_track  += mem_details_per_chip[n].num_cpus;
+                    continue;
+                }
+                for(ti=0;ti<mem_details_per_chip[n].num_cpus;ti++){
+                    rc = pthread_join(shm_alloc_th[cpus_track+ti].tid,NULL);
+                    if(rc != 0) {
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:pthread_join failed rc = %d and errno = %d(%s)"
+                            " for thread %d\n",__LINE__,__FUNCTION__,rc,errno,strerror(errno),cpus_track+ti);
+                        return (FAILURE);
+                    }
+                }				
+                cpus_track      += mem_details_per_chip[n].num_cpus;
+                for(pi = 0;pi<MAX_PAGE_SIZES;pi++){
+                    if(!g_data.sys_details.chip_mem_pool_data[n].memory_details.pdata[pi].supported)continue;
+                    if(g_data.sys_details.chip_mem_pool_data[n].memory_details.pdata[pi].page_wise_seg_data != NULL){
+                        free(g_data.sys_details.chip_mem_pool_data[n].memory_details.pdata[pi].page_wise_seg_data);
+                    }
+                }
+            }
+        #ifndef __HTX_LINUX__
+            if (mem_g.affinity == LOCAL ) {
+                rc = system("vmo -d enhanced_affinity_vmpool_limit");
+                displaym(HTX_HE_INFO,DBG_IMP_PRINT,"%s():vmo -d enhanced_affinity_vmpool_limit rc=%d \t errno =%d\n",\
+                __FUNCTION__,rc,errno);
+            }
+        #endif
+        }else{
+            tot_sys_threads = g_data.gstanza.global_num_threads;
+            for(ti=0;ti<tot_sys_threads;ti++){
+                debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"Creating thread %d to deallocate memory \n",ti);
+                rc = pthread_create((pthread_t *)&shm_alloc_th[ti].tid,NULL,remove_shm,(void *)&shm_alloc_th[ti]);
+                if(rc !=0 ){
+                    displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s:pthread_create failed rc = %d and errno = %d(%s),thread_num=%d\n",
+                        __LINE__,__FUNCTION__,rc,errno,strerror(errno),ti);
+                    return (FAILURE);
+                }
+            }
+            for(ti=0;ti<tot_sys_threads;ti++){
+                rc = pthread_join(shm_alloc_th[ti].tid,NULL);
+                if(rc != 0) {
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:pthread_join failed rc = %d and errno = %d(%s)"
+                        " for thread %d\n",__LINE__,__FUNCTION__,rc,errno,strerror(errno),ti);
+                     return (FAILURE);
+                }
+            }
+            for(pi = 0;pi<MAX_PAGE_SIZES;pi++){
+                if(!g_data.sys_details.memory_details.pdata[pi].supported)continue;
+                if(g_data.sys_details.memory_details.pdata[pi].page_wise_seg_data != NULL){
+                    free(g_data.sys_details.memory_details.pdata[pi].page_wise_seg_data);
+                }
+            }
+        }
+        if(shm_alloc_th != NULL){
+            free(shm_alloc_th);
+            shm_alloc_th = NULL;
+        }	
+        mem_g.shm_cleanup_done = 1;
+        return SUCCESS;
+
+    }
+    void* get_shm(void* t){
+        struct shm_alloc_th_data *th = (struct shm_alloc_th_data *)t;
+        struct chip_mem_pool_info* mem_details_per_chip  = &g_data.sys_details.chip_mem_pool_data[0];
+        struct mem_info* sys_mem_details = &g_data.sys_details.memory_details;
+        int n = th->chip_num;
+        int rc,pi,seg_num,num_segs=0,seg_inc = 0;;
+        int tot_cpus = g_data.gstanza.global_num_threads;
+        if(!g_data.gstanza.global_disable_cpu_bind){
+        /*replace below call with bind_to_cpu,common betweeen AIX/LINUX*/
+        #ifndef __HTX_LINUX__
+            if (g_data.cpu_DR_flag != 1){
+                rc = bindprocessor(BINDTHREAD,thread_self(),th->bind_cpu_num);
+            }
+        #else
+            rc = htx_bind_thread(th->bind_cpu_num,-1);
+        #endif
+
+            if(rc < 0){/*REV: hotplug/dr need to take care*/
+                    displaym(HTX_HE_INFO,DBG_MUST_PRINT,"bind call failed for cpu %d (th:%d),local memory may not be guaranteed\n",th->bind_cpu_num,th->thread_num);
+            } 
+        }
+        for(pi=0;pi<MAX_PAGE_SIZES; pi++) {
+            if(!sys_mem_details->pdata[pi].supported){
+                continue;
+            }
+            if(g_data.gstanza.global_disable_filters == 0){
+                /*segs per chip per page pool will divided among threads of same chip,such that each seg index will be picked up by a cpu (segment_index%total_cpus_in_that_chip)*/
+                if(mem_details_per_chip[n].memory_details.pdata[pi].free == 0){
+                    continue;
+                }
+                num_segs = mem_details_per_chip[n].memory_details.pdata[pi].num_of_segments;
+                seg_num = th->chip_cpu_num % mem_details_per_chip[n].num_cpus;
+                seg_inc = mem_details_per_chip[n].num_cpus;
+            }else{
+                if(sys_mem_details->pdata[pi].free == 0){
+                    continue;
+                }
+                num_segs = sys_mem_details->pdata[pi].num_of_segments;
+                seg_num = th->thread_num % tot_cpus;
+                seg_inc = tot_cpus;
+            }
+            while(seg_num < num_segs ){
+                /*displaym(HTX_HE_INFO,DBG_DEBUG_PRINT,"seg_num=%d of page pool=%s in chip %d will be aloocated by thread %d,cpu %d\n",seg_num,page_size_name[pi],n,th->thread_num,th->bind_cpu_num);*/
+                rc = allocate_buffers(pi,seg_num,th);
+                if(rc != SUCCESS){
+                    g_data.exit_flag = 1;
+                    displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"[%d]%s:allocate_buffers failed with rc = %d for allocation thread %d, page pool = %s\n", \
+                                    __LINE__,__FUNCTION__,rc,th->thread_num,page_size_name[pi]);
+                    pthread_exit((void *)1);
+                }
+                /*seg_num +=  mem_details_per_chip[n].num_cpus;*/
+                seg_num += seg_inc;
+            }
+        }
+
+        if(!g_data.gstanza.global_disable_cpu_bind){
+        /*replace below call with bind_to_cpu,common betweeen AIX/LINUX*/
+        #ifndef __HTX_LINUX__
+            rc = bindprocessor(BINDTHREAD, th->tid,-1);
+        #else
+            rc = htx_unbind_thread();
+        #endif
+        }
+    }
+    void* remove_shm(void* t){
+
+        struct shm_alloc_th_data *th = (struct shm_alloc_th_data *)t;
+        struct chip_mem_pool_info* mem_details_per_chip  = &g_data.sys_details.chip_mem_pool_data[0];
+        struct mem_info* sys_mem_details = &g_data.sys_details.memory_details;
+        int n = th->chip_num;
+        int rc,pi,seg_num=0,num_segs=0,seg_inc = 0;;
+        int tot_cpus = g_data.gstanza.global_num_threads;
+
+        for(pi=0;pi<MAX_PAGE_SIZES; pi++) {
+            if(!sys_mem_details->pdata[pi].supported){
+                continue;
+            }
+            if(g_data.gstanza.global_disable_filters == 0){
+                if(mem_details_per_chip[n].memory_details.pdata[pi].free == 0){
+                    continue;
+                }
+                num_segs = mem_details_per_chip[n].memory_details.pdata[pi].num_of_segments;
+                seg_num=0;
+                seg_num = th->chip_cpu_num % mem_details_per_chip[n].num_cpus;
+                seg_inc = mem_details_per_chip[n].num_cpus;
+            }else{
+                if(sys_mem_details->pdata[pi].free == 0){
+                    continue;
+                }
+                num_segs = sys_mem_details->pdata[pi].num_of_segments;
+                seg_num=th->thread_num % tot_cpus;
+                seg_inc = tot_cpus;
+            }
+            while(seg_num < num_segs ){
+                /*displaym(HTX_HE_INFO,DBG_DEBUG_PRINT,"seg_num=%d of page pool=%s in chip %d will be aloocated by thread %d,cpu %d\n",seg_num,page_size_name[pi],n,th->thread_num,th->bind_cpu_num);*/
+                rc = deallocate_buffers(pi,seg_num,th);
+                if(rc != SUCCESS){
+                    displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"[%d]%s:deallocate_buffers failed with rc = %d for allocation thread %d, page pool = %s\n", \
+                                    __LINE__,__FUNCTION__,rc,th->thread_num,page_size_name[pi]);
+                    pthread_exit((void *)1);
+                }
+                seg_num += seg_inc;
+            }
+        }
+    }
+
+    int allocate_buffers(int pi, int seg_num, struct shm_alloc_th_data *th){
+        unsigned long i, memflg;
+        int n = th->chip_num; 
+        int bound_cpu = th->bind_cpu_num;
+    #ifndef __HTX_LINUX__
+        struct shmid_ds shm_buf = { 0 };
+    #endif
+        struct page_wise_seg_info *seg_details = NULL;
+
+        if(g_data.gstanza.global_disable_filters == 0){
+            seg_details = &g_data.sys_details.chip_mem_pool_data[n].memory_details.pdata[pi].page_wise_seg_data[seg_num];
+        }else{
+            seg_details = &g_data.sys_details.memory_details.pdata[pi].page_wise_seg_data[seg_num];
+        }
+
+        if(g_data.gstanza.global_disable_cpu_bind){
+            bound_cpu = -1;
+        }
+    #ifndef __HTX_LINUX__
+        memflg = (IPC_CREAT | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+    #else
+        memflg = (IPC_CREAT | IPC_EXCL |SHM_R | SHM_W);
+        if(pi >= PAGE_INDEX_2M) {
+            memflg |= (SHM_HUGETLB);
+        }
+    #endif
+        if (g_data.exit_flag == 1) {
+             pthread_exit((void *)1);
+        } /* endif */
+        seg_details->shmid = shmget (IPC_PRIVATE, seg_details->shm_size, memflg);
+        if(seg_details->shmid  == -1){
+            char msg[1024];
+            sprintf(msg,"[%d]%s:shmget failed with -1 by thread = %d(bound to cpu:%d) for size=%lu,seg_num=%d,page pool=%s,errno:%d(%s)\n", \
+                    __LINE__,__FUNCTION__,th->thread_num,bound_cpu,seg_details->shm_size,seg_num,page_size_name[pi],errno,strerror(errno));	
+            if(errno == ENOMEM){
+                strcat(msg,"Looks like previous htx run was not a clean exit,Please check if any stale shared memory chunks are present" 
+                    ",clear them or reboot the partition, make sure desired free memory is avialable in the system before re starting the test.\n"); 
+            }
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"%s\n",msg);
+            return (FAILURE);
+        }
+        else {
+            debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"(shmget success)thread:%d for page:%s, shm id[%d]=%lu and size = %lu\n",
+                        th->thread_num,page_size_name[pi],seg_num,seg_details->shmid,seg_details->shm_size);
+        }
+    #ifndef __HTX_LINUX__
+        if ( seg_details->shm_size > (256*MB)) {
+            if (shmctl(seg_details->shmid,SHM_GETLBA, &shm_buf)) {	
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s: shmctl failed with err:(%d)%s, for seg_num = %d,shm_id=%lu while setting SHM_GETLBA"
+                    "for page = %s and segment_size = %lu \n",__LINE__,__FUNCTION__,errno,strerror(errno),seg_num,seg_details->shmid,page_size_name[pi],seg_details->shm_size);	
+                return  (FAILURE);
+            }
+        }	
+        shm_buf.shm_pagesize = g_data.sys_details.memory_details.pdata[pi].psize;
+
+        if (shmctl(seg_details->shmid,SHM_PAGESIZE, &shm_buf)) {
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:shmctl failed with err:(%d)%s,for seg_num = %d,shm_id=%lu,thread=%d while setting SHM_PAGESIZE"
+                        " for page = %s and segment_size = %lu \n",__LINE__,__FUNCTION__,errno,strerror(errno),seg_num,seg_details->shmid,th->thread_num,page_size_name[pi],seg_details->shm_size);
+            return  (FAILURE);
+        }
+    #endif
+        seg_details->shm_mem_ptr = (void *)shmat(seg_details->shmid,(char *) 0, 0);
+        if (seg_details->shm_mem_ptr  == (void *)-1) {
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:shmat failed with err:(%d)%s,for seg_num = %d,shm_id=%lu while setting SHM_PAGESIZE"
+                     "for page = %s and segment_size = %lu \n",__LINE__,__FUNCTION__,errno,strerror(errno),seg_num,seg_details->shmid,page_size_name[pi],seg_details->shm_size);
+            return (FAILURE);
+        }
+        debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"(shmat success)Allocated/Attached  shared memory buffer%d, id = %lu, shm_memp = "
+                "0x%lx and page size =%s by thread : %d\n",seg_num,seg_details->shmid,seg_details->shm_mem_ptr,page_size_name[pi],th->thread_num);
+
+        /* write 8 byte value to every page of this segment*/
+        long long* temp_ptr = (long long*) seg_details->shm_mem_ptr;
+        unsigned long num_pages = 	seg_details->shm_size/g_data.sys_details.memory_details.pdata[pi].psize;
+        for(i =0; i < num_pages; i++)
+        {
+            *temp_ptr = 0xBBBBBBBBBBBBBBBBULL;
+            temp_ptr += (g_data.sys_details.memory_details.pdata[pi].psize/8);
+
+        }
+        /* initialize other parameters of segment management structure*/
+        seg_details->owning_thread   = -1;
+        seg_details->page_size_index = pi;
+        seg_details->in_use			 = 0;
+        seg_details->cpu_chip_num		 = -1; 
+        seg_details->mem_chip_num		 = th->chip_num; 
+
+        return (SUCCESS);
+    }
+
+    int deallocate_buffers(int pi, int seg_num, struct shm_alloc_th_data *th){
+
+        int rc;
+        int n = th->chip_num; 
+        struct page_wise_seg_info *seg_details = NULL;
+
+        if(g_data.gstanza.global_disable_filters == 0){
+            seg_details = &g_data.sys_details.chip_mem_pool_data[n].memory_details.pdata[pi].page_wise_seg_data[seg_num];
+        }else{
+            seg_details = &g_data.sys_details.memory_details.pdata[pi].page_wise_seg_data[seg_num];
+        }
+        if (seg_details->shm_mem_ptr != NULL) {/* If shared memory head pointer is allocated */
+            debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"Removing segment #%d of page size %s by thread: %d "
+                "shm_mem id=%lu, shm_memp = 0x%lx\n",seg_num,page_size_name[pi],th->thread_num,seg_details->shmid,seg_details->shm_mem_ptr);
+            rc = shmdt(seg_details->shm_mem_ptr);
+            if(rc != 0){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:(th:%d)shmdt failed with err:(%d)%s,at adress:0x%lx for seg_num = %d,shm_id=%lu for page = %s"
+                "and segment_size = %lu \n",__LINE__,__FUNCTION__,th->thread_num,errno,strerror(errno),seg_details->shm_mem_ptr,seg_num,seg_details->shmid,page_size_name[pi],seg_details->shm_size);
+                return (FAILURE);
+            }
+            rc = shmctl(seg_details->shmid,IPC_RMID,(struct shmid_ds *) NULL);
+            if (rc != 0) {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:(th:%d)shmctl failed with err:(%d)%s,for seg_num = %d,shm_id=%lu for page = %s"
+                "and segment_size = %lu \n",__LINE__,__FUNCTION__,th->thread_num,errno,strerror(errno),seg_num,seg_details->shmid,page_size_name[pi],seg_details->shm_size);
+                return (FAILURE);
+            }
+            debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"Released shared memory buffer %d id = %d, shm_memp = 0x%lx page size = %s\n",
+            seg_num,seg_details->shmid,seg_details->shm_mem_ptr,page_size_name[pi]);
+            seg_details->shm_mem_ptr = NULL;
+        }
+        return SUCCESS;
+    }
+
+    int apply_filters(){
+
+        struct cpu_filter_info* cf = &g_data.stanza_ptr->filter.cf;
+        struct mem_filter_info* mf = &g_data.stanza_ptr->filter.mf;
+        struct chip_mem_pool_info* chp = &g_data.sys_details.chip_mem_pool_data[0];
+        struct page_wise_data *page_wise_details=NULL;
+        struct page_wise_data *sys_page_wise_details=NULL;
+        int node,chip,core,lcpu,pi,seg,sys_chip_count = 0;
+        long long mem_in_use = 0;
+        
+        if(g_data.gstanza.global_disable_filters == 0){
+            g_data.stanza_ptr->num_threads = 0;
+            for(chip =0; chip<MAX_CHIPS;chip++){
+                chp[chip].in_use_num_cpus= 0;
+                chp[chip].is_chip_mem_in_use= FALSE;
+                for(int j=0;j<MAX_CPUS_PER_SRAD;j++){
+                    chp[chip].in_use_cpulist[j] = -1;
+                }
+                for(pi=0;pi<MAX_PAGE_SIZES;pi++){
+                    chp[chip].memory_details.pdata[pi].page_wise_usage_mem = 0;
+                    chp[chip].memory_details.pdata[pi].in_use_num_of_segments = 0;
+                }
+
+            }
+
+            for( node = 0; node < g_data.sys_details.nodes; node++){
+                if(cf->node[node].node_num ==-1){
+                    sys_chip_count += g_data.sys_details.node[node].num_chips;
+                    continue;
+                }
+                for(chip = 0; chip < g_data.sys_details.node[node].num_chips; chip++){
+                    if(cf->node[node].chip[chip].chip_num == -1){/*if cpu filter tells not to consider this chip  then do not populate cpus*/
+                        sys_chip_count++;
+                        continue;
+                    }
+                    for(core = 0; core < MAX_CORES_PER_CHIP; core++){
+                        if(cf->node[node].chip[chip].core[core].core_num == -1){
+                            continue;
+                        }
+                        for(lcpu=0;lcpu < MAX_CPUS_PER_CORE;lcpu++){
+                            if(cf->node[node].chip[chip].core[core].lprocs[lcpu] == -1){
+                                continue;
+                            }
+                            chp[sys_chip_count].in_use_cpulist[chp[sys_chip_count].in_use_num_cpus++] = cf->node[node].chip[chip].core[core].lprocs[lcpu];
+                            g_data.stanza_ptr->num_threads++;
+                        }        
+                    }
+                    sys_chip_count++;
+                }
+
+            }
+
+            sys_chip_count = 0;
+            for( node = 0; node < get_num_of_nodes_in_sys(); node++){
+                if(mf->node[node].node_num ==-1){
+                    sys_chip_count += get_num_of_chips_in_node(node);
+                    continue;
+                }
+                for(chip = 0; chip < get_num_of_chips_in_node(node); chip++){
+                    if(mf->node[node].chip[chip].chip_num == -1){
+                        sys_chip_count++;
+                        continue;
+                    }
+                    chp[sys_chip_count].is_chip_mem_in_use= TRUE;
+                    page_wise_details = &g_data.sys_details.chip_mem_pool_data[sys_chip_count].memory_details.pdata[0];
+                    for(pi=0;pi<MAX_PAGE_SIZES;pi++){
+                        mem_in_use = 0;
+                        if(!(page_wise_details[pi].supported) || (mf->node[node].chip[chip].mem_details.pdata[pi].page_wise_usage_mem == 0)){
+                            continue;
+                        }
+                        page_wise_details[pi].page_wise_usage_mem = mf->node[node].chip[chip].mem_details.pdata[pi].page_wise_usage_mem;
+                        for(seg=0;seg<page_wise_details[pi].num_of_segments;seg++){
+                            /*reset the segment size field with original value,which might have got modified by previous stanza mem filter*/
+                            page_wise_details[pi].page_wise_seg_data[seg].shm_size =  page_wise_details[pi].page_wise_seg_data[seg].original_shm_size;
+                            /* If rule file has entry of segment size for a given page,if it is less than original alocated seg size then overwirte with new*/
+                            if(g_data.stanza_ptr->seg_size[pi] != -1){
+                                if(g_data.stanza_ptr->seg_size[pi] < page_wise_details[pi].page_wise_seg_data[seg].shm_size){
+                                    page_wise_details[pi].page_wise_seg_data[seg].shm_size = g_data.stanza_ptr->seg_size[pi];
+                                }
+                            }
+                            if(page_wise_details[pi].page_wise_usage_mem < page_wise_details[pi].page_wise_seg_data[seg].shm_size){
+                                page_wise_details[pi].page_wise_seg_data[seg].shm_size = page_wise_details[pi].page_wise_usage_mem;
+                                page_wise_details[pi].page_wise_seg_data[seg].in_use = 0;
+                                page_wise_details[pi].in_use_num_of_segments++;
+                                break;
+                            }
+                            mem_in_use += page_wise_details[pi].page_wise_seg_data[seg].shm_size;
+                            if(mem_in_use > page_wise_details[pi].page_wise_usage_mem)break;
+                            page_wise_details[pi].page_wise_seg_data[seg].in_use = 0;
+                            page_wise_details[pi].in_use_num_of_segments++;
+                        }
+                    }            
+                    sys_chip_count++;
+                }
+            } 
+        }else{
+            int dma_mem_percent = g_data.stanza_ptr->mem_percent;
+            int dma_cpu_percent = g_data.stanza_ptr->cpu_percent;
+            if((g_data.stanza_ptr->operation == OPER_DMA) || (g_data.stanza_ptr->operation == OPER_RIM)){
+                if(g_data.stanza_ptr->mem_percent == DEFAULT_MEM_PERCENT){
+                    dma_mem_percent = 5;
+                }
+                if(g_data.stanza_ptr->cpu_percent == DEFAULT_CPU_PERCENT){
+                    dma_cpu_percent = 10;
+                }
+            }
+            sys_page_wise_details = &g_data.sys_details.memory_details.pdata[0];
+            for(pi=0;pi<MAX_PAGE_SIZES;pi++){
+                mem_in_use = 0;
+                sys_page_wise_details[pi].page_wise_usage_mem = 0;
+                sys_page_wise_details[pi].in_use_num_of_segments = 0;
+                if(!(sys_page_wise_details[pi].supported) || (sys_page_wise_details[pi].free == 0)){
+                    continue;
+                }
+                if(pi < PAGE_INDEX_2M){
+                    sys_page_wise_details[pi].page_wise_usage_mem = sys_page_wise_details[pi].free * (g_data.gstanza.global_alloc_mem_percent/100.0);/*allocated memory*/
+                    sys_page_wise_details[pi].page_wise_usage_mem = sys_page_wise_details[pi].page_wise_usage_mem * (dma_mem_percent/100.0);
+                    sys_page_wise_details[pi].page_wise_usage_mem = sys_page_wise_details[pi].page_wise_usage_mem / sys_page_wise_details[pi].psize;
+                    sys_page_wise_details[pi].page_wise_usage_mem = sys_page_wise_details[pi].page_wise_usage_mem * sys_page_wise_details[pi].psize;
+                }else{
+                    sys_page_wise_details[pi].page_wise_usage_mem = sys_page_wise_details[pi].free;
+                }
+
+
+                for(seg=0;seg<sys_page_wise_details[pi].num_of_segments;seg++){
+                    /*reset the segment size field with original value,which might have got modified by previous stanza mem filter*/
+                    sys_page_wise_details[pi].page_wise_seg_data[seg].shm_size =  sys_page_wise_details[pi].page_wise_seg_data[seg].original_shm_size;
+                    /* If rule file has entry of segment size for a given page,if it is less than original alocated seg size then overwirte with new*/
+                    if(g_data.stanza_ptr->seg_size[pi] != -1){
+                        if(g_data.stanza_ptr->seg_size[pi] < sys_page_wise_details[pi].page_wise_seg_data[seg].shm_size){
+                            sys_page_wise_details[pi].page_wise_seg_data[seg].shm_size = g_data.stanza_ptr->seg_size[pi];
+                        }
+                    }
+                    if(sys_page_wise_details[pi].page_wise_usage_mem < sys_page_wise_details[pi].page_wise_seg_data[seg].shm_size){
+                        sys_page_wise_details[pi].page_wise_seg_data[seg].shm_size = sys_page_wise_details[pi].page_wise_usage_mem;
+                        sys_page_wise_details[pi].in_use_num_of_segments++;
+                        break;
+                    }
+                    mem_in_use += sys_page_wise_details[pi].page_wise_seg_data[seg].shm_size;
+                    if(mem_in_use > sys_page_wise_details[pi].page_wise_usage_mem)break;
+                    sys_page_wise_details[pi].in_use_num_of_segments++;
+                }
+            }
+            /*check for "num_threads" mentioned in rule, else check for "cpu_percent", other wise set it to g_num_threads(global stanza, deafault value - total lcpus)*/
+            if(g_data.stanza_ptr->num_threads == -1){
+                if(g_data.stanza_ptr->cpu_percent < 100){
+                    g_data.stanza_ptr->num_threads = (g_data.sys_details.tot_cpus * (dma_cpu_percent/100.0));
+                    if (g_data.stanza_ptr->num_threads == 0){
+                        g_data.stanza_ptr->num_threads = 1;
+                    }
+                }else{
+                    g_data.stanza_ptr->num_threads = g_data.gstanza.global_num_threads;
+                }
+            }
+        }
+        return SUCCESS;
+    }
+
+    int fill_thread_context(){
+        int i,chip,rc,start_thread_index=0;
+        struct chip_mem_pool_info *chp = &g_data.sys_details.chip_mem_pool_data[0];
+        int mem_chip_used[MAX_CHIPS] = {[0 ...(MAX_CHIPS-1)]=-1};
+
+        g_data.thread_ptr = (struct thread_data*)malloc(sizeof(struct thread_data) * g_data.stanza_ptr->num_threads);
+        if(g_data.thread_ptr == NULL){
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s: malloc failed to allocate %d bytes of memory with error(%d):%s, total threads =%d\n",
+                __LINE__,__FUNCTION__,(sizeof(struct thread_data) * g_data.stanza_ptr->num_threads),errno,strerror(errno),g_data.stanza_ptr->num_threads);
+            return(FAILURE);
+        
+        }
+        for(i=0;i<g_data.stanza_ptr->num_threads;i++){
+            g_data.thread_ptr[i].thread_num = -1;
+            g_data.thread_ptr[i].bind_proc = -1;
+
+        }
+        mem_g.mem_th_data = (struct mem_exer_thread_info*)malloc(sizeof(struct mem_exer_thread_info) * g_data.stanza_ptr->num_threads);
+        if(mem_g.mem_th_data == NULL){
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s: malloc failed to allocate %d bytes of memory with error(%d):%s, total threads =%d\n",
+                __LINE__,__FUNCTION__,(sizeof(struct mem_exer_thread_info) * g_data.stanza_ptr->num_threads),errno,strerror(errno),g_data.stanza_ptr->num_threads);
+            return(FAILURE);
+        }
+        if(g_data.gstanza.global_disable_filters == 1){
+            rc = fill_thread_context_with_filters_disabled();
+            if(rc != SUCCESS){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:fill_thread_context_with_filters_disabled() failed with rc = %d\n",
+                    __LINE__,__FUNCTION__,rc);
+                return (FAILURE);
+            }
+            return (SUCCESS);		
+        }
+        for(chip = 0; chip < MAX_CHIPS; chip++){
+            if(chp[chip].in_use_num_cpus <= 0)continue;
+
+            switch(mem_g.affinity){
+                case LOCAL:
+                    if((chp[chip].is_chip_mem_in_use != TRUE) || (chp[chip].in_use_num_cpus <= 0)){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s: Specified filter in rule file %s, rule_id:%s  resulted into  _NO_ cpu or mem usage for chip %d ,"
+                            "please correct the filters or change affinity=LOCAL setting\n",__LINE__,__FUNCTION__,g_data.rules_file_name,g_data.stanza_ptr->rule_id,chip);
+                        return (FAILURE);
+                    }    
+                    rc = fill_affinity_based_thread_structure(&chp[chip],&chp[chip],start_thread_index);
+                    if(rc != SUCCESS){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:fill_affinity_based_thread_structure() returned rc = %d\n",__LINE__,__FUNCTION__,rc);
+                        return (FAILURE);
+                    }
+                    break;
+                case REMOTE_CHIP:
+                    {
+                        long int mem_chip=chip;
+                        for(;;){
+                            mem_chip = (mem_chip + 1)%g_data.sys_details.num_chip_mem_pools;
+                            if(mem_chip == chip){
+                                displaym(HTX_HE_INFO,DBG_MUST_PRINT,"[%d]%s: (affinity=REMOTE_CHIP)for cpu chip %d,there is no remote memory "
+                                    "chip is provided in memory filters for rule=%s,rule file=%s\n,over writing to affinity = local, please "
+                                    "check system config or modify filters to run remote_chip test.\n"
+                                    ,__LINE__,__FUNCTION__,chip,g_data.stanza_ptr->rule_id,g_data.rules_file_name);
+                                mem_g.affinity = LOCAL;
+                                break;
+                            }
+                            if(mem_chip_used[mem_chip] == 1){
+                                continue;
+                            }
+                            if(chp[mem_chip].is_chip_mem_in_use == TRUE) {
+                                break;
+                            } 
+                        }
+                        debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"affity(remote_chip):cpu chip = %d mem chip = %d th=%d\n",chip,mem_chip,start_thread_index);
+                        mem_chip_used[mem_chip] = 1;
+                        rc = fill_affinity_based_thread_structure(&chp[chip],&chp[mem_chip],start_thread_index);
+                        if(rc != SUCCESS){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:fill_affinity_based_thread_structure() returned rc = %d\n",__LINE__,__FUNCTION__,rc);
+                            return (FAILURE);
+                        }
+                    }
+                    break;
+
+                case FLOATING:
+                    g_data.stanza_ptr->disable_cpu_bind = 1;
+                    rc = fill_affinity_based_thread_structure(&chp[chip],&chp[chip],start_thread_index);
+                    if(rc != SUCCESS){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:fill_affinity_based_thread_structure() returned rc = %d\n",__LINE__,__FUNCTION__,rc);
+                        return (FAILURE);
+                    }
+                    break;
+                default:
+                    displaym(HTX_HE_INFO,DBG_MUST_PRINT,"[%d]%s:Inavlid affinity value provided in rule file %s,rule_id:%s, over writing it to 'LOCAL' and continuing..\n",
+                        __LINE__,__FUNCTION__,g_data.rules_file_name,g_data.stanza_ptr->rule_id);            
+                    mem_g.affinity = LOCAL;
+                    if((chp[chip].is_chip_mem_in_use != TRUE) || (chp[chip].in_use_num_cpus <= 0)){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s: Specified filter in rule file %s, rule_id:%s  resulted into  _NO_ cpu or mem usage for chip %d ,"
+                            "please correct the filters or change affinity=LOCAL setting\n",__LINE__,__FUNCTION__,g_data.rules_file_name,g_data.stanza_ptr->rule_id,chip);
+                        return (FAILURE);
+                    }    
+                    rc = fill_affinity_based_thread_structure(&chp[chip],&chp[chip],start_thread_index);
+                    if(rc != SUCCESS){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:fill_affinity_based_thread_structure() returned rc = %d\n",__LINE__,__FUNCTION__,rc);
+                        return (FAILURE);
+                    }
+            }
+
+            start_thread_index += chp[chip].in_use_num_cpus;
+            
+        }    
+
+
+        return(SUCCESS);
+    }
+
+    int fill_affinity_based_thread_structure(struct chip_mem_pool_info *cpu_chip, struct chip_mem_pool_info *mem_chip,int start_thread_index){
+
+        int thread_num,pi;
+        int rem_segs[MAX_PAGE_SIZES],avg_segs_per_thread[MAX_PAGE_SIZES],seg_count_track[MAX_PAGE_SIZES];
+        int num_threads_in_this_chip = cpu_chip->in_use_num_cpus;
+        int num_segs_per_thread[num_threads_in_this_chip][MAX_PAGE_SIZES];
+        struct thread_data* th = &g_data.thread_ptr[start_thread_index];
+
+        for(pi=0;pi<MAX_PAGE_SIZES;pi++){
+            seg_count_track[pi] = 0;
+            if(mem_chip->memory_details.pdata[pi].in_use_num_of_segments > 0){
+                if(mem_chip->memory_details.pdata[pi].in_use_num_of_segments >= num_threads_in_this_chip){
+                    avg_segs_per_thread[pi] = (mem_chip->memory_details.pdata[pi].in_use_num_of_segments/num_threads_in_this_chip);
+                }else {
+                    avg_segs_per_thread[pi] = 0;
+                }
+                rem_segs[pi] = (mem_chip->memory_details.pdata[pi].in_use_num_of_segments % num_threads_in_this_chip);
+                
+        
+            }
+            
+        }
+        for(thread_num=0;thread_num < num_threads_in_this_chip; thread_num++){
+            struct mem_exer_thread_info *local_ptr = &(mem_g.mem_th_data[thread_num+start_thread_index]);
+            th[thread_num].testcase_thread_details = (void *)local_ptr;
+            th[thread_num].thread_num               = thread_num+start_thread_index;
+            th[thread_num].bind_proc                = cpu_chip->in_use_cpulist[thread_num];
+            th[thread_num].thread_type              = MEM;
+            local_ptr->num_segs = 0;
+            for(pi=0;pi<MAX_PAGE_SIZES;pi++){
+                if(mem_chip->memory_details.pdata[pi].in_use_num_of_segments > 0){
+                    num_segs_per_thread[thread_num][pi]=avg_segs_per_thread[pi];
+                    local_ptr->num_segs += avg_segs_per_thread[pi];
+                    if((rem_segs[pi]--) > 0){
+                        local_ptr->num_segs++;
+                        num_segs_per_thread[thread_num][pi]++;               
+                    }
+                }
+
+            }
+            if(local_ptr->num_segs != 0){
+                local_ptr->seg_details = (struct page_wise_seg_info*) malloc(local_ptr->num_segs * sizeof(struct page_wise_seg_info));
+                if(local_ptr->seg_details == NULL){
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:malloc failed for memory %d bytes with errno(%d)%s, num_segs for thread %d = %d\n",
+                        __LINE__,__FUNCTION__,(local_ptr->num_segs * sizeof(struct page_wise_seg_info)),errno,strerror(errno),th[thread_num].thread_num,local_ptr->num_segs);
+                    return(FAILURE);
+                }
+            }
+
+        }
+        for(thread_num=0;thread_num < num_threads_in_this_chip; thread_num++){
+            /*th[thread_num].testcase_thread_details  = (struct mem_exer_thread_info*) &mem_g.mem_th_data[thread_num+start_thread_index];
+            struct mem_exer_thread_info *local_ptr = (struct mem_exer_thread_info*)th[thread_num].testcase_thread_details;*/
+            struct mem_exer_thread_info *local_ptr = &(mem_g.mem_th_data[thread_num+start_thread_index]);
+            th[thread_num].testcase_thread_details = (void *)local_ptr;
+            debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"thread:%d cpu to bind=%d total segments: %d \n",th[thread_num].thread_num,th[thread_num].bind_proc,local_ptr->num_segs);
+            int j = 0;
+            if(local_ptr->num_segs == 0)continue;
+            for(pi=0;pi<MAX_PAGE_SIZES;pi++){
+                if((mem_chip->memory_details.pdata[pi].in_use_num_of_segments > 0) && (seg_count_track[pi] < mem_chip->memory_details.pdata[pi].in_use_num_of_segments)){
+                    debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"   Page:%s  num_segs=%d\n",page_size_name[pi],num_segs_per_thread[thread_num][pi]);
+                    for(int seg=0;(seg < num_segs_per_thread[thread_num][pi]) && (j < local_ptr->num_segs);seg++,j++){
+                        if(mem_chip->memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track [pi]].owning_thread != -1)continue;
+                        local_ptr->seg_details[j].owning_thread = th[thread_num].thread_num;
+                        local_ptr->seg_details[j].page_size_index   = pi;
+                        local_ptr->seg_details[j].shmid             = mem_chip->memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track[pi]].shmid;
+                        local_ptr->seg_details[j].shm_size          = mem_chip->memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track[pi]].shm_size;
+                        local_ptr->seg_details[j].shm_mem_ptr       = mem_chip->memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track[pi]].shm_mem_ptr;
+                        local_ptr->seg_details[j].seg_num           = mem_chip->memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track[pi]].seg_num;
+                        local_ptr->seg_details[j].mem_chip_num      = mem_chip->memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track[pi]].mem_chip_num;
+                        local_ptr->seg_details[j].cpu_chip_num      = cpu_chip->chip_id;
+
+                        /*update thread number in global segment details data structure*/
+                        mem_chip->memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track [pi]].owning_thread =th[thread_num].thread_num;
+                        mem_chip->memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track[pi]].cpu_chip_num = cpu_chip->chip_id;
+                        mem_chip->memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track[pi]].in_use=1;
+
+                        debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"      seg_details[%d]=%d(count/th =%d),mem_chip=%d, owning_thread=%d,shmid=%lu,shm_size=%lu,EA=%llx\n",
+                            (seg+seg_count_track[pi]),local_ptr->seg_details[j].seg_num,j,local_ptr->seg_details[j].mem_chip_num,local_ptr->seg_details[j].owning_thread,
+                            local_ptr->seg_details[j].shmid,local_ptr->seg_details[j].shm_size,local_ptr->seg_details[j].shm_mem_ptr);
+                    }
+                    seg_count_track[pi] += num_segs_per_thread[thread_num][pi];
+                }
+            }
+        }
+        return (SUCCESS);
+    }
+
+    int fill_thread_context_with_filters_disabled(){
+
+        int thread_num,pi;
+        int rem_segs[MAX_PAGE_SIZES],avg_segs_per_thread[MAX_PAGE_SIZES],seg_count_track[MAX_PAGE_SIZES];
+        int total_threads = g_data.stanza_ptr->num_threads;
+        int num_segs_per_thread[total_threads][MAX_PAGE_SIZES];
+        struct thread_data* th = &g_data.thread_ptr[0];
+
+        for(pi=0;pi<MAX_PAGE_SIZES;pi++){
+            seg_count_track[pi] = 0;
+            if(g_data.sys_details.memory_details.pdata[pi].in_use_num_of_segments > 0){
+                if(g_data.sys_details.memory_details.pdata[pi].in_use_num_of_segments >= total_threads){
+                    avg_segs_per_thread[pi] = (g_data.sys_details.memory_details.pdata[pi].in_use_num_of_segments / total_threads);
+                }else{
+                    avg_segs_per_thread[pi] = 0;
+                }
+                rem_segs[pi] = (g_data.sys_details.memory_details.pdata[pi].in_use_num_of_segments % total_threads);
+            }/*else{
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:in_use_num_of_segments=%lu, something went wrong in segment calculation, \n",
+                    __LINE__,__FUNCTION__,g_data.sys_details.memory_details.pdata[pi].in_use_num_of_segments);
+                return(FAILURE);
+            }*/		
+        }
+
+        for(thread_num=0;thread_num < total_threads;thread_num++){
+            struct mem_exer_thread_info *local_ptr = &(mem_g.mem_th_data[thread_num]);
+            th[thread_num].testcase_thread_details = (void *)local_ptr;
+            th[thread_num].thread_num               = thread_num;
+            th[thread_num].bind_proc                = thread_num;
+            th[thread_num].thread_type              = MEM;
+            local_ptr->num_segs = 0;
+            for(pi=0;pi<MAX_PAGE_SIZES;pi++){
+                if(g_data.sys_details.memory_details.pdata[pi].in_use_num_of_segments > 0){
+                    num_segs_per_thread[thread_num][pi]=avg_segs_per_thread[pi];
+                    local_ptr->num_segs += avg_segs_per_thread[pi];
+                    if((rem_segs[pi]--) > 0){
+                        local_ptr->num_segs++;
+                        num_segs_per_thread[thread_num][pi]++;
+                    }
+                }
+            }
+            if(local_ptr->num_segs != 0){
+                local_ptr->seg_details = (struct page_wise_seg_info*) malloc(local_ptr->num_segs * sizeof(struct page_wise_seg_info));
+                if(local_ptr->seg_details == NULL){
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:malloc failed for memory %d bytes with errno(%d)%s, num_segs for thread %d = %d\n",
+                        __LINE__,__FUNCTION__,(local_ptr->num_segs * sizeof(struct page_wise_seg_info)),errno,strerror(errno),th[thread_num].thread_num,local_ptr->num_segs);
+                    return(FAILURE);
+                }
+            }
+        }
+
+        for(thread_num=0;thread_num < total_threads;thread_num++){
+            struct mem_exer_thread_info *local_ptr = &(mem_g.mem_th_data[thread_num]);
+            th[thread_num].testcase_thread_details = (void *)local_ptr;
+            debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"thread:%d cpu to bind=%d total segments: %d \n",th[thread_num].thread_num,th[thread_num].bind_proc,local_ptr->num_segs);
+            int j = 0;
+            if(local_ptr->num_segs == 0)continue;
+            for(pi=0;pi<MAX_PAGE_SIZES;pi++){
+                if((g_data.sys_details.memory_details.pdata[pi].in_use_num_of_segments > 0) && (seg_count_track[pi] < g_data.sys_details.memory_details.pdata[pi].in_use_num_of_segments)){
+                    debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"   Page:%s  num_segs=%d\n",page_size_name[pi],num_segs_per_thread[thread_num][pi]);
+                    for(int seg=0;(seg < num_segs_per_thread[thread_num][pi]) && (j < local_ptr->num_segs);seg++,j++){
+                        if(g_data.sys_details.memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track [pi]].owning_thread != -1)continue;
+                        local_ptr->seg_details[j].owning_thread = th[thread_num].thread_num;
+                        local_ptr->seg_details[j].page_size_index   = pi;
+                        local_ptr->seg_details[j].shmid             = g_data.sys_details.memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track [pi]].shmid;
+                        local_ptr->seg_details[j].shm_size			= g_data.sys_details.memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track [pi]].shm_size;
+                        local_ptr->seg_details[j].shm_mem_ptr       = g_data.sys_details.memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track [pi]].shm_mem_ptr;
+                        local_ptr->seg_details[j].seg_num			= g_data.sys_details.memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track [pi]].seg_num;
+                        local_ptr->seg_details[j].mem_chip_num      = -1;/* In case of affinity=no/disable_filter mode/shared proc, its not possible to update chip nums*/
+                        local_ptr->seg_details[j].cpu_chip_num      = -1;				
+                    
+                        /*update thread number in global segment details data structure*/
+                        g_data.sys_details.memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track [pi]].owning_thread =th[thread_num].thread_num;
+                        g_data.sys_details.memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track [pi]].cpu_chip_num = -1;
+                        g_data.sys_details.memory_details.pdata[pi].page_wise_seg_data[seg +seg_count_track [pi]].in_use = 1;
+
+                        debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"      seg_details[%d]=%d(count/th =%d),mem_chip=%d, owning_thread=%d,shmid=%lu,shm_size=%lu,EA=%llx\n",
+                            (seg+seg_count_track[pi]),local_ptr->seg_details[j].seg_num,j,local_ptr->seg_details[j].mem_chip_num,local_ptr->seg_details[j].owning_thread,
+                            local_ptr->seg_details[j].shmid,local_ptr->seg_details[j].shm_size,local_ptr->seg_details[j].shm_mem_ptr);
+                    }
+                    seg_count_track[pi] += num_segs_per_thread[thread_num][pi];
+                }
+            }
+        }
+        return (SUCCESS);
+    }
+
+    int create_and_run_thread_operation(){
+        int rc,thread_num,tnum,thread_track=0;
+        struct thread_data* th = &g_data.thread_ptr[0];
+        void *tresult;
+        for(thread_num=0;thread_num < g_data.stanza_ptr->num_threads;thread_num++){
+            struct mem_exer_thread_info *local_ptr = &(mem_g.mem_th_data[thread_num]);
+            th[thread_num].testcase_thread_details = (void *)local_ptr;
+            tnum = thread_num;
+            th[thread_num].tid= -1;
+            th[thread_num].kernel_tid = -1;
+            if(local_ptr->num_segs == 0) continue;
+            /*displaym(HTX_HE_INFO,DBG_IMP_PRINT,"Creating thread %d for cpu num : %d for exercising total segs = %d\n",thread_num,th[tnum].bind_proc,local_ptr->num_segs);*/
+
+            rc = pthread_create((pthread_t *)&th[tnum].tid,NULL,mem_thread_function,&th[tnum]);
+            if(rc != 0){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"pthread_create failed with rc = %d (errno %d):(%s) for thread_num = %d\n",rc,errno,strerror(errno),tnum);
+                return(FAILURE);
+            }
+            thread_track++;
+        }
+        if(thread_track != g_data.stanza_ptr->num_threads){
+            displaym(HTX_HE_INFO,DBG_MUST_PRINT,"Actual threads created %d (mem filter resulted into less number of segments),"
+                "where as total threads to be created as per cpu filters=%d \n", thread_track,g_data.stanza_ptr->num_threads);
+        }
+        thread_track =0;
+        for(thread_num=0;thread_num < g_data.stanza_ptr->num_threads;thread_num++){
+            struct mem_exer_thread_info *local_ptr = &(mem_g.mem_th_data[thread_num]);
+            th[thread_num].testcase_thread_details = (void *)local_ptr;
+            tnum = thread_num;
+            if(local_ptr->num_segs == 0) {
+                th[thread_num].thread_num= -1;
+                th[thread_num].bind_proc = -1;
+                th[thread_num].tid= -1;
+                th[thread_num].kernel_tid = -1;
+                continue;
+            }
+            rc = pthread_join(th[tnum].tid,&tresult);
+            if(rc != 0){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"pthread_join with rc = %d (errno %d):(%s) for thread_num = %d \n",rc,errno,strerror(errno),thread_num);
+                return(FAILURE);
+            }   
+            thread_track++;
+            th[thread_num].thread_num= -1;
+            th[thread_num].tid= -1; 
+            th[thread_num].kernel_tid = -1;
+            th[thread_num].bind_proc = -1;
+        }
+        if(thread_track != g_data.stanza_ptr->num_threads){
+            displaym(HTX_HE_INFO,DBG_MUST_PRINT,"Total threads joined %d \n",thread_track);
+        }
+
+        rc = reset_segment_owners();
+        return (SUCCESS);
+    }
+
+
+
+    void* mem_thread_function(void *tn){
+        int rc;
+        struct thread_data* th = (struct thread_data*)tn;
+        struct mem_exer_thread_info *local_ptr = &(mem_g.mem_th_data[th->thread_num]);
+        th->testcase_thread_details = (void *)local_ptr;
+        debug(HTX_HE_INFO,DBG_IMP_PRINT,"Thread(%d):Inside mem_thread_function binding to cpu %d,segs=%d\n",th->thread_num,th->bind_proc,local_ptr->num_segs);
+
+        if(!g_data.stanza_ptr->disable_cpu_bind){
+            /*replace below call with bind_to_cpu,common betweeen AIX/LINUX*/
+        #ifndef __HTX_LINUX__
+            th->kernel_tid = thread_self();
+            rc = bindprocessor(BINDTHREAD,th->kernel_tid,th->bind_proc);
+        #else
+            rc = htx_bind_thread(th->bind_proc,-1);
+        #endif
+            if(rc < 0){
+            #ifdef __HTX_LINUX__
+                if (rc == -2 || rc == -1) {
+                    displaym(HTX_HE_INFO,DBG_IMP_PRINT,"(th:%d)lcpu : %d has been hot removed\n",th->thread_num,th->bind_proc);
+                }else{
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT," bind to cpu %d by thread %d is failed with rc = %d,err:%d(%s)\n",
+                        th->bind_proc,th->thread_num,rc,errno,strerror(errno));
+                    release_thread_resources(th->thread_num);
+                    pthread_exit((void *)1);
+                }
+            #else
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT," bind to cpu %d by thread %d is failed with rc = %d,err:%d(%s)\n",
+                    th->bind_proc,th->thread_num,rc,errno,strerror(errno));
+                release_thread_resources(th->thread_num);
+                pthread_exit((void *)1);
+            #endif
+            }
+            
+        }
+
+        switch(g_data.stanza_ptr->operation){
+            case OPER_MEM:
+                rc = do_mem_operation(th->thread_num);
+                break;
+
+            case OPER_RIM:
+                rc = do_rim_operation(th->thread_num);
+                break;
+
+            case OPER_DMA:
+                if(!mem_g.dma_flag){
+                    rc = do_dma_operation(th->thread_num);
+                }
+                break;
+
+            case OPER_STRIDE:
+                rc = do_stride_operation(th->thread_num);
+                break;
+
+            default:
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:The stanza's (%s) oper(%s) field"
+                    "is invalid.Please check the oper field \n",__LINE__,__FUNCTION__,g_data.stanza_ptr->rule_id,g_data.stanza_ptr->oper);
+        }
+
+        release_thread_resources(th->thread_num);
+        pthread_exit((void *)0);
+    }
+
+    int do_mem_operation(int t){
+        int  num_oper,miscompare_count,seg,pi=0,rc=0,misc_detected = 0; /* pi is pattern index */
+        static int main_misc_count=0;
+        struct segment_detail sd;
+        struct thread_data* th = &g_data.thread_ptr[t];
+        struct mem_exer_thread_info *local_ptr = &(mem_g.mem_th_data[t]);
+        th->testcase_thread_details = (void *)local_ptr;
+        int nw=0,nr=0,nc=0,trap_flag=0,mem_access_type_index;
+        unsigned long seed = g_data.stanza_ptr->seed;
+        unsigned long backup_seed = seed;
+        
+        debug(HTX_HE_INFO,DBG_IMP_PRINT,"Starting load_store_buffers with num_oper = %d for thread[%d]= %d to exercise tot segs=%d cpu = %d \n"
+                        ,g_data.stanza_ptr->num_oper,t,th->thread_num,local_ptr->num_segs,th->bind_proc);
+        if( (g_data.stanza_ptr->misc_crash_flag) && (g_data.kdb_level) )
+            trap_flag = 1;    /* Trap is set */
+        else
+            trap_flag = 0;    /* Trap is not set */
+
+        if(g_data.stanza_ptr->attn_flag)
+            trap_flag = 2;    /* attn is set */
+
+
+        for (num_oper =0;num_oper < g_data.stanza_ptr->num_oper; num_oper++){
+            if(g_data.mem_DR_flag){
+                displaym(HTX_HE_INFO,DBG_MUST_PRINT,"Thread: %d is exiting for current stanza on mem DR operation \n",t);
+                return(-1);
+            }
+            for (seg=0;seg<local_ptr->num_segs;){
+                sd.page_index=local_ptr->seg_details[seg].page_size_index;
+                sd.seg_num=local_ptr->seg_details[seg].seg_num;
+                sd.seg_size=local_ptr->seg_details[seg].shm_size;
+                sd.owning_thread = local_ptr->seg_details[seg].owning_thread;
+                sd.cpu_owning_chip = local_ptr->seg_details[seg].cpu_chip_num;
+                sd.mem_owning_chip = local_ptr->seg_details[seg].mem_chip_num;;
+                sd.affinity_index  = g_data.stanza_ptr->affinity;
+                sd.thread_ptr_addr = (unsigned long)th;
+                sd.global_ptr_addr = (unsigned long)&g_data;
+                sd.sub_seg_num=0;
+                sd.sub_seg_size=0;
+                backup_seed = seed;
+                if( g_data.stanza_ptr->pattern_type[pi] == PATTERN_ADDRESS ) {
+                    sd.width = LS_DWORD;
+                } else {
+                    sd.width = g_data.stanza_ptr->width;
+                }
+                nw = g_data.stanza_ptr->num_writes;
+                nr = g_data.stanza_ptr->num_reads;
+                nc = g_data.stanza_ptr->num_compares;
+                mem_access_type_index = get_mem_access_operation(pi);
+                while(nw>0 || nr>0 || nc>0){
+                    if(nw>0){
+                        seed = backup_seed;
+                        rc = (*operation_fun_typ[g_data.stanza_ptr->pattern_type[pi]][WRITE][mem_access_type_index])(
+                                                                (sd.seg_size/sd.width),\
+                                                                local_ptr->seg_details[seg].shm_mem_ptr,\
+                                                                g_data.stanza_ptr->pattern[pi],\
+                                                                trap_flag,\
+                                                                &sd,\
+                                                                g_data.stanza_ptr,\
+                                                                &g_data.stanza_ptr->pattern_size[pi],\
+                                                                (unsigned long)&seed);
+                        nw--;
+                    }
+                        debug(HTX_HE_INFO,DBG_MUST_PRINT,"Thread: %d  complted %d Write  operations, for seg = %d(page_wise seg #%d),page=%d,pat=%d\n",
+                            t,nw,seg,sd.seg_num,page_size_name[sd.page_index],pi);
+                    if (g_data.exit_flag == 1) {
+                        goto update_exit;
+                    } /* endif */
+                
+                    if(nr>0){ 
+                        rc = (*operation_fun_typ[g_data.stanza_ptr->pattern_type[pi]][READ][mem_access_type_index])(
+                                                                (sd.seg_size/sd.width),\
+                                                                local_ptr->seg_details[seg].shm_mem_ptr,\
+                                                                g_data.stanza_ptr->pattern[pi],\
+                                                                trap_flag,\
+                                                                &sd,\
+                                                                g_data.stanza_ptr,\
+                                                                &g_data.stanza_ptr->pattern_size[pi],\
+                                                                (unsigned long)&seed);
+
+                        /*displaym(HTX_HE_INFO,DBG_MUST_PRINT,"Thread: %d  complted %d Read operations\n",t,nr);*/
+                        nr--;
+                    }
+                    if (g_data.exit_flag == 1) {
+                        goto update_exit;
+                    } /* endif */
+
+                    if(nc>0){
+                        rc = (*operation_fun_typ[g_data.stanza_ptr->pattern_type[pi]][COMPARE][mem_access_type_index])(
+                                                                (sd.seg_size/sd.width),\
+                                                                local_ptr->seg_details[seg].shm_mem_ptr,\
+                                                                g_data.stanza_ptr->pattern[pi],\
+                                                                trap_flag,\
+                                                                &sd,\
+                                                                g_data.stanza_ptr,\
+                                                                &g_data.stanza_ptr->pattern_size[pi],\
+                                                                (unsigned long)&backup_seed);
+                        if(rc != SUCCESS){
+                            displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"[%d]%s:compare_data returned %d for compare count %d\n",
+                                __LINE__,__FUNCTION__,rc,nc);
+                            break;
+                
+                        }
+                        debug(HTX_HE_INFO,DBG_MUST_PRINT,"Thread: %d  complted %d Read_Cmpare operations\n",t,nc);
+                        nc--; 
+                    }
+                    if (g_data.exit_flag == 1 && rc == SUCCESS) {
+                        goto update_exit;
+                    } /* endif */
+
+                }
+                if(rc != SUCCESS){/* If there is any miscompare, rc will have the offset */
+                    miscompare_count = dump_miscompared_buffers(t,rc,seg,main_misc_count,(unsigned long)&backup_seed,num_oper,trap_flag,pi,&sd);
+                    STATS_VAR_INC(bad_others, 1);
+                    main_misc_count++;
+                    misc_detected++ ;
+                    STATS_VAR_INC(bad_others, 1)
+                    STATS_HTX_UPDATE(UPDATE)
+                }
+                if (g_data.exit_flag == 1) {
+                    goto update_exit;
+                } /* endif */
+                /* hxfupdate(UPDATE,&stats);*/
+
+                switch(g_data.stanza_ptr->switch_pat) {
+                     case SW_PAT_ALL:               /* SWITCH_PAT_PER_SEG = ALL */
+                        /* Stay on this segment until all patterns are tested.
+                        Advance segment index once for every num_patterns */
+                        pi++;
+                        if (pi >= g_data.stanza_ptr->num_patterns) {
+                            pi = 0; /* Go back to the 1st pattern */
+                            seg++;        /* Move to the new Seg */
+                        }
+                         break;
+                    case SW_PAT_ON:                /* SWITCH_PAT_PER_SEG = YES */
+                        /* Go back to the 1st pattern */
+                        pi++;
+                        if (pi >= g_data.stanza_ptr->num_patterns) {
+                            pi = 0;
+                        }
+                        /* Fall through */
+                    case SW_PAT_OFF:                /* SWITCH_PAT_PER_SEG = NO */
+                        /* Fall through */
+                        default:
+                        seg++;        /* Increment Seg idx: case 1,0 and default */
+                } /* end of switch */
+
+            update_exit:
+                STATS_VAR_INC(bytes_writ,((g_data.stanza_ptr->num_writes - nw) * sd.seg_size))
+                STATS_VAR_INC(bytes_read,((g_data.stanza_ptr->num_reads - nr) * sd.seg_size))
+                STATS_VAR_INC(bytes_read,((g_data.stanza_ptr->num_compares - nc - misc_detected) * sd.seg_size))
+                STATS_HTX_UPDATE(UPDATE)
+                misc_detected = 0;
+                if (g_data.exit_flag == 1) {
+                    return -1;
+                }
+            }/*seg loop*/
+
+        }/* num_oper loop*/
+        return (SUCCESS);
+    }
+
+    int do_rim_operation(int t){
+        int  k,num_oper,miscompare_count,seg,pi=0,rc=0,misc_detected = 0; /* pi is pattern index */
+        static int main_misc_count=0;
+        struct segment_detail sd;
+        struct thread_data* th = &g_data.thread_ptr[t];
+        struct mem_exer_thread_info *local_ptr = &(mem_g.mem_th_data[t]);
+        th->testcase_thread_details = (void *)local_ptr;
+        int nw=0,trap_flag=0,mem_access_type_index;
+        unsigned long seed = g_data.stanza_ptr->seed,seg_size;
+        unsigned long backup_seed = seed;
+
+        debug(HTX_HE_INFO,DBG_IMP_PRINT,"Starting load_store_buffers with num_oper = %d for thread[%d]= %d to exercise tot segs=%d cpu = %d \n"
+                        ,g_data.stanza_ptr->num_oper,t,th->thread_num,local_ptr->num_segs,th->bind_proc);
+        if( (g_data.stanza_ptr->misc_crash_flag) && (g_data.kdb_level) )
+            trap_flag = 1;    /* Trap is set */
+        else
+            trap_flag = 0;    /* Trap is not set */
+
+        if(g_data.stanza_ptr->attn_flag)
+            trap_flag = 2;    /* attn is set */
+
+
+        for (num_oper =0;num_oper < g_data.stanza_ptr->num_oper; num_oper++){
+            if(g_data.mem_DR_flag){
+                displaym(HTX_HE_INFO,DBG_MUST_PRINT,"Thread: %d is exiting for current stanza on mem DR operation \n",t);
+                return(-1);
+            }
+            for (seg=0;seg<local_ptr->num_segs;){
+                sd.page_index=local_ptr->seg_details[seg].page_size_index;
+                sd.seg_num=local_ptr->seg_details[seg].seg_num;
+                sd.seg_size=local_ptr->seg_details[seg].shm_size;
+                sd.owning_thread = local_ptr->seg_details[seg].owning_thread;
+                sd.cpu_owning_chip = local_ptr->seg_details[seg].cpu_chip_num;
+                sd.mem_owning_chip = local_ptr->seg_details[seg].mem_chip_num;;
+                sd.affinity_index  = g_data.stanza_ptr->affinity;
+                sd.thread_ptr_addr = (unsigned long)th;
+                sd.global_ptr_addr = (unsigned long)&g_data;
+                sd.sub_seg_num=-1;
+                sd.sub_seg_size=DEF_SEG_SZ_4K;
+                backup_seed = seed;
+                if( g_data.stanza_ptr->pattern_type[pi] == PATTERN_ADDRESS ) {
+                    sd.width = LS_DWORD;
+                } else {
+                    sd.width = g_data.stanza_ptr->width;
+                }
+                /* 16G page segment is logically operated in 256MB chunks
+                 *  to test for RIM operation only*/
+                if ( sd.page_index  == PAGE_INDEX_16G ) {
+                    seg_size = sd.sub_seg_size;
+                } else {
+                    seg_size = local_ptr->seg_details[seg].shm_size;
+                }
+                nw = g_data.stanza_ptr->num_writes;
+                mem_access_type_index = get_mem_access_operation(pi);
+                while(nw>0){
+                seed = backup_seed;
+                    for(k=0;(k*seg_size < sd.seg_size);k++){/*k operates on next sub segments */
+                        sd.sub_seg_num=k;
+                        rc = (*operation_fun_typ[g_data.stanza_ptr->pattern_type[pi]][RIM][mem_access_type_index])
+                                                                ((sd.seg_size/sd.width),\
+                                                                local_ptr->seg_details[seg].shm_mem_ptr+k*seg_size,\
+                                                                g_data.stanza_ptr->pattern[pi],\
+                                                                trap_flag,\
+                                                                &sd,\
+                                                                g_data.stanza_ptr,\
+                                                                &g_data.stanza_ptr->pattern_size[pi],\
+                                                                (unsigned long)&seed);
+        
+                        debug(HTX_HE_INFO,DBG_MUST_PRINT,"Thread: %d  complted %d RIM operations(write,read,flush,readcompare), for seg = %d(page_wise seg #%d),page=%d,pat=%d\n",
+                            t,nw,seg,sd.seg_num,page_size_name[sd.page_index],pi);
+                        if (g_data.exit_flag == 1) {
+                            goto update_exit;
+                        }    /* endif */
+                        nw--;
+                    }
+                }
+                if(rc != SUCCESS){/* If there is any miscompare, rc will have the offset */
+                    miscompare_count = dump_miscompared_buffers(t,rc,seg,main_misc_count,(unsigned long)&seed,num_oper,trap_flag,pi,&sd);
+                    STATS_VAR_INC(bad_others, 1);
+                    main_misc_count++;
+                    misc_detected++ ;
+                    STATS_VAR_INC(bad_others, 1)
+                    STATS_HTX_UPDATE(UPDATE)
+                }
+                if (g_data.exit_flag == 1) {
+                    goto update_exit;
+                } /* endif */
+                /* hxfupdate(UPDATE,&stats);*/
+
+                switch(g_data.stanza_ptr->switch_pat) {
+                     case SW_PAT_ALL:               /* SWITCH_PAT_PER_SEG = ALL */
+                        /* Stay on this segment until all patterns are tested.
+                        Advance segment index once for every num_patterns */
+                        pi++;
+                        if (pi >= g_data.stanza_ptr->num_patterns) {
+                            pi = 0; /* Go back to the 1st pattern */
+                            seg++;        /* Move to the new Seg */
+                        }
+                         break;
+                    case SW_PAT_ON:                /* SWITCH_PAT_PER_SEG = YES */
+                        /* Go back to the 1st pattern */
+                        pi++;
+                        if (pi >= g_data.stanza_ptr->num_patterns) {
+                            pi = 0;
+                        }
+                        /* Fall through */
+                    case SW_PAT_OFF:                /* SWITCH_PAT_PER_SEG = NO */
+                        /* Fall through */
+                        default:
+                        seg++;        /* Increment Seg idx: case 1,0 and default */
+                } /* end of switch */
+
+            update_exit:
+                STATS_VAR_INC(bytes_writ,((g_data.stanza_ptr->num_writes - nw - misc_detected) * WRC * sd.seg_size))
+                STATS_HTX_UPDATE(UPDATE)
+                misc_detected = 0;
+                if (g_data.exit_flag == 1) {
+                    return -1;
+                }
+            }/*seg loop*/
+
+        }/* num_oper loop*/
+        return SUCCESS;
+    }
+
+    int do_dma_operation(int t){
+        int  num_oper,miscompare_count,seg,pi=0,rc=0,misc_detected = 0; /* pi is pattern index */
+        int  chars_read,fildes,file_size,mode_flag;
+        static int main_misc_count=0;
+        struct segment_detail sd;
+        struct thread_data* th = &g_data.thread_ptr[t];
+        struct mem_exer_thread_info *local_ptr = &(mem_g.mem_th_data[t]);
+        th->testcase_thread_details = (void *)local_ptr;
+        int nw=0,nr=0,nc=0,trap_flag=0,mem_access_type_index;
+        unsigned long seed = g_data.stanza_ptr->seed;
+        struct stat fstat;
+        char *ptr;
+        char pattern_nm[256];
+        unsigned long pat_size;
+
+        char* pat_tmp_ptr = getenv("HTXPATTERNS");
+        if(pat_tmp_ptr == NULL){
+            displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s(): env variable HTXPATTERNS is not set,pat_tmp_ptr=%p"
+                ", thus exiting..\n",__LINE__,__FUNCTION__,pat_tmp_ptr);
+            return(-1);
+        }else{
+            strcpy(pattern_nm,pat_tmp_ptr);
+        }
+        strcat(pattern_nm,g_data.stanza_ptr->pattern_name[0]);
+        pat_size = g_data.stanza_ptr->pattern_size[0];
+
+        debug(HTX_HE_INFO,DBG_IMP_PRINT,"\n(T=%d)Entered do_dma_operation() pattern name=%s,nam=%s , size=%u \n",\
+            t,pattern_nm,g_data.stanza_ptr->pattern_name[0],pat_size);
+
+        if( (g_data.stanza_ptr->misc_crash_flag) && (g_data.kdb_level) )
+            trap_flag = 1;    /* Trap is set */
+        else
+            trap_flag = 0;    /* Trap is not set */
+
+        if(g_data.stanza_ptr->attn_flag)
+            trap_flag = 2;    /* attn is set */
+
+        mode_flag = S_IWUSR | S_IWGRP | S_IWOTH;
+        /* Opening the file in Direct I/O mode ( or what can be called RAW mode ) */
+        #ifndef __HTX_BML__
+        if ((fildes = open(pattern_nm, O_DIRECT | O_RDONLY , mode_flag)) == -1) {
+        #else
+        if ((fildes = open(pattern_nm, O_RDONLY , mode_flag)) == -1) {
+        #endif
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s():thread %d, open() failed for file %s,errno:%d(%s)\n",\
+                __LINE__,__FUNCTION__,t,pattern_nm,errno,strerror(errno));
+            return FAILURE;
+        }
+        for (num_oper =0;num_oper < g_data.stanza_ptr->num_oper; num_oper++){
+            if(stat (pattern_nm, &fstat) == -1){
+                 displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s():thread %d,Error(%s(%d)) while getting the pattern %s"
+                    " file stats",__LINE__,__FUNCTION__,t,strerror(errno),errno,pattern_nm);
+            }else{
+                file_size=fstat.st_size;
+            }
+            if (pat_size > file_size ) {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s():thread %d,pat_size(%ld) cannot be greater than file's (%s) size %d",
+                    __LINE__,__FUNCTION__,t,pat_size,pattern_nm,file_size);
+                return FAILURE;      
+            }
+            for (seg=0;seg<local_ptr->num_segs;seg++){
+                nw = g_data.stanza_ptr->num_writes;
+                nr = g_data.stanza_ptr->num_reads;
+                nc = g_data.stanza_ptr->num_compares;
+                mem_access_type_index = get_mem_access_operation(pi);
+                long seg_size = local_ptr->seg_details[seg].shm_size;
+                unsigned long total_bytes_read = 0; /* Temporary variable */
+                unsigned int read_size = 0;
+                sd.page_index=local_ptr->seg_details[seg].page_size_index;
+                sd.seg_num=local_ptr->seg_details[seg].seg_num;
+                sd.seg_size=local_ptr->seg_details[seg].shm_size;
+                sd.owning_thread = local_ptr->seg_details[seg].owning_thread;
+                sd.cpu_owning_chip = local_ptr->seg_details[seg].cpu_chip_num;
+                sd.mem_owning_chip = local_ptr->seg_details[seg].mem_chip_num;;
+                sd.affinity_index  = g_data.stanza_ptr->affinity;
+                sd.thread_ptr_addr = (unsigned long)th;
+                sd.global_ptr_addr = (unsigned long)&g_data;
+                sd.sub_seg_num=0;
+                sd.sub_seg_size=0;            
+                sd.width = g_data.stanza_ptr->width;
+                while(nw>0 || nr>0 || nc>0){
+                    if(nw>0){
+                        seg_size = sd.seg_size;
+                        total_bytes_read = 0; /* Temporary variable */
+                        ptr = local_ptr->seg_details[seg].shm_mem_ptr;
+                        while ( seg_size > 0 ) {
+                            /* Rewind file before each read(write into memory) */
+                            if(total_bytes_read% pat_size == 0 ) {
+                                rc = lseek(fildes,0,0);
+                                if (rc == -1) {
+                                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s():thread %d,lseek error(%s(%d))on file %d\n",
+                                        __LINE__,__FUNCTION__,t,strerror(errno),errno,pattern_nm);
+                                    return(FAILURE);
+                                }
+                            }    
+                            if ( (seg_size/pat_size) == 0) {
+                                read_size = seg_size%pat_size;
+                            } else {
+                                read_size = pat_size;
+                            }
+
+                            if ((chars_read = read(fildes, ptr, read_size)) == -1) {
+                                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s():thread %d,error reading from disk(%s(%d)) - %s, "
+                                "file_size =%d, chars_read =%d,page size=%s, seg_num=%ld, seg_addr=0x%llx\n", __LINE__,__FUNCTION__,
+                                t,strerror(errno),errno,pattern_nm,file_size,chars_read,page_size_name[sd.page_index],seg,ptr);
+                                return(FAILURE);
+                            }
+                            if (g_data.exit_flag == 1) {
+                                return(-1);
+                            }
+                            if (chars_read < read_size) {
+                                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s():thread %d,ot able to read from disk - %s, "
+                                "properly patt_size=%d,file_size =%d, chars_read =%d, err=%d, page size =%s,seg_num=%ld\n", __LINE__,
+                                __FUNCTION__,t,g_data.stanza_ptr->pattern_name[0],pat_size,file_size,chars_read,errno,page_size_name[sd.page_index],seg);
+                                return(FAILURE);
+                            }else{/* If we dont update time stamp of htx, mem may result in hungi(with mdt.bu),due to heavy sys call read() operation*/
+                                STATS_HTX_UPDATE(UPDATE)
+                            }	
+                            /* Now we have successfully read chars_read bytes */
+                            total_bytes_read += chars_read;
+                            ptr+=chars_read;
+                           seg_size-=chars_read;
+                        }/*ends while (seg_size> 0 )*/                
+                        nw--;
+                    }/*ends if(nw>0*/
+                    if(nr > 0){
+                        rc = (*operation_fun_typ[g_data.stanza_ptr->pattern_type[pi]][READ][mem_access_type_index])(
+                                                                (sd.seg_size/g_data.stanza_ptr->width),\
+                                                                local_ptr->seg_details[seg].shm_mem_ptr,\
+                                                                g_data.stanza_ptr->pattern[pi],\
+                                                                0,\
+                                                                0,\
+                                                                g_data.stanza_ptr,\
+                                                                &g_data.stanza_ptr->pattern_size[pi],\
+                                                                NULL);                    
+                        nr--;
+                    }         
+                    if (g_data.exit_flag == 1) {
+                        goto update_exit;
+                    }
+                    if(nc > 0){
+                        rc = (*operation_fun_typ[g_data.stanza_ptr->pattern_type[pi]][COMPARE][mem_access_type_index])(
+                                                                (sd.seg_size/g_data.stanza_ptr->width),\
+                                                                local_ptr->seg_details[seg].shm_mem_ptr,\
+                                                                g_data.stanza_ptr->pattern[pi],\
+                                                                trap_flag,\
+                                                                &sd,\
+                                                                g_data.stanza_ptr,\
+                                                                &g_data.stanza_ptr->pattern_size[pi],\
+                                                                NULL);
+                        if(rc != SUCCESS){
+                            displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"[%d]%s:compare_data returned %d for compare count %d\n",
+                                __LINE__,__FUNCTION__,rc,nc);
+                            break;
+                        }
+                        nc--;
+                    }
+                    if (g_data.exit_flag == 1 && rc == SUCCESS) {
+                        goto update_exit;
+                    } /* endif */                
+                    if(rc != SUCCESS){/* If there is any miscompare, rc will have the offset */
+                        miscompare_count = dump_miscompared_buffers(t,rc,seg,main_misc_count,&seed,num_oper,trap_flag,pi,&sd);
+                        STATS_VAR_INC(bad_others, 1);
+                        main_misc_count++;
+                        misc_detected++ ;
+                        STATS_VAR_INC(bad_others, 1)
+                        STATS_HTX_UPDATE(UPDATE)
+                    }
+                }/* end of while(nw>0 || nr>0 || nc>0)*/
+                update_exit:
+                STATS_VAR_INC(bytes_writ,((g_data.stanza_ptr->num_writes - nw) * sd.seg_size))
+                STATS_VAR_INC(bytes_read,((g_data.stanza_ptr->num_reads - nr) * sd.seg_size))
+                STATS_VAR_INC(bytes_read,((g_data.stanza_ptr->num_compares - nc - misc_detected) * sd.seg_size))
+                STATS_HTX_UPDATE(UPDATE)
+                misc_detected = 0;
+                if (g_data.exit_flag == 1) {
+                    return -1;
+                }
+            }/*ends seg loop*/
+        }/*ends num_oper loop*/
+        close(fildes);
+        return SUCCESS;
+    }
+
+    int dump_miscompared_buffers(int ti, unsigned long rc, int seg, int main_misc_count,
+            unsigned long *seed_ptr,int pass,int trap_flag,int pi,struct segment_detail* sd){
+        char fname[128], msg_text[4096],msg_temp[4096];
+        struct thread_data* th = &g_data.thread_ptr[ti];
+        struct mem_exer_thread_info *local_ptr = &(mem_g.mem_th_data[ti]);
+        th->testcase_thread_details = (void *)local_ptr;
+        int miscompare_count=0, page_offset;
+        int  tmp_shm_size=0,buffer_size;
+        int ps = local_ptr->seg_details[seg].page_size_index;
+        unsigned long new_offset=0;
+        unsigned long pat_offset=0; /* pattern offset when pat len > 8 we need this */
+        unsigned long expected_pat = 0; /* pattern value which is expected */
+        char bit_pattern[8];
+        char *shm_mem_ea = local_ptr->seg_details[seg].shm_mem_ptr;
+     
+        int mem_access_type_index = get_mem_access_operation(pi);
+        int width = sd->width;
+        displaym(HTX_HE_SOFT_ERROR, DBG_MUST_PRINT,"MISCOMPARE DETECTED, "
+                 "Details:segment number=%d,page size=%s,"
+                 "width=%d ,shared memory size = 0x%lx and seed = 0x%lx,ptr=%p,rc=%ld\n",
+                 seg,page_size_name[ps],width,local_ptr->seg_details[seg].shm_size,*seed_ptr,local_ptr->seg_details[seg].shm_mem_ptr,rc);
+
+        if (ps == PAGE_INDEX_16G) {
+            new_offset = sd->sub_seg_num*sd->sub_seg_size;
+        }
+
+        do
+        {
+            displaym(HTX_HE_SOFT_ERROR, DBG_MUST_PRINT, "#1.0.dump_miscompared_buffers\n");
+            pat_offset = ((rc-1+(new_offset/width))*(width))\
+                                        %(g_data.stanza_ptr->pattern_size[pi]);
+            if (g_data.stanza_ptr->pattern_type[pi] == PATTERN_RANDOM ) {
+                expected_pat = *seed_ptr;
+            }else {
+                if (g_data.stanza_ptr->pattern_type[pi] == PATTERN_ADDRESS ) {
+                    expected_pat =  (unsigned long)(shm_mem_ea+((rc-1)*(width)+new_offset));
+                }
+                else {
+                    expected_pat = *(unsigned long *)(&g_data.stanza_ptr->pattern[pi][pat_offset]);
+                }
+
+            }
+            memcpy(bit_pattern,(char*)&expected_pat,sizeof(unsigned long));
+
+            sprintf(msg_text,"MEMORY MISCOMPARE(hxemem64) in stanza %s,num_oper = %d,Rules file=%s\n"
+                    "Segment deatils:   seg#:%lu shm  id:%lu\nShared memory Segment Starting EA=0x%p,\n"
+                    "size = %lu \nShared memory segment consists of pages of size =%s\n"
+                    "read/write width = %d, Trap_Flag = %d Sub-Segment Number=%d, Thread=%d,num_of_threads=%d\n"
+                    "(Ignore if affinity=FLOATING)hip  details: cpu:%d belongs to chip:%d, Memory  belongs to chip= %d\n"
+                    "Miscompare Offset in the Shared memory segment is (%ld x %d) %ld bytes from the "
+                    "starting location,\nData expected = 0x%lx\nData retrieved: ",
+                    g_data.stanza_ptr->rule_id,pass,g_data.rules_file_name,\
+                    local_ptr->seg_details[seg].seg_num,local_ptr->seg_details[seg].shmid,shm_mem_ea,\
+                    local_ptr->seg_details[seg].shm_size,page_size_name[ps],\
+                    width,trap_flag,sd->sub_seg_num,ti,g_data.stanza_ptr->num_threads,th->bind_proc, \
+                    local_ptr->seg_details[seg].cpu_chip_num, local_ptr->seg_details[seg].mem_chip_num,\
+                    (rc-1+(new_offset/width)),width, \
+                    (rc-1+(new_offset/width))*(width),\
+                    expected_pat);
+
+            switch(width){
+
+                /*Need to take care of prints in case of LE mode*/
+                case LS_DWORD: {
+                            sprintf(msg_temp,"miscomparing dword(0x%lx)"
+                                     " at dword Address(%p)\nActual misc Addr=%p,misc dword data=0x%lx\n",\
+                                    *(unsigned long *)(shm_mem_ea +((((rc-1)*(width))/MIN_PATTERN_SIZE)*MIN_PATTERN_SIZE)+new_offset),
+                                    (shm_mem_ea + ((((rc-1)*(width))/MIN_PATTERN_SIZE)*MIN_PATTERN_SIZE)+new_offset),\
+                                    (shm_mem_ea + (rc-1)*(width)+new_offset),\
+                                    *(unsigned long*)(shm_mem_ea +(rc-1)*(width)+new_offset));
+                            break;
+                        }
+                case LS_WORD: {
+                            sprintf(msg_temp,"miscomparing word(0x%x)"
+                                     " at dword Address(0x%p)\nActual misc Addr=0x%p,misc data word=0x%x\n",\
+                                    *(unsigned int*)(shm_mem_ea + ((((rc-1)*(width))/MIN_PATTERN_SIZE)*MIN_PATTERN_SIZE)+new_offset),
+                                    (shm_mem_ea + ((((rc-1)*(width))/MIN_PATTERN_SIZE)*MIN_PATTERN_SIZE)+new_offset),\
+                                    (shm_mem_ea + (rc-1)*(width)+new_offset),\
+                                    *(unsigned int*)(shm_mem_ea + (rc-1)*(width)+new_offset));
+                            break;
+                        }
+                case LS_BYTE: {
+                            sprintf(msg_temp,"miscomparing byte(0x%x)"
+                                     " at dword Address(0x%p)\nActual misc Addr=0x%p,misc data byte=0x%x\n",\
+                                    *(unsigned char *)(shm_mem_ea + ((((rc-1)*(width))/MIN_PATTERN_SIZE)*MIN_PATTERN_SIZE)+new_offset),
+                                    (shm_mem_ea + ((((rc-1)*(width))/LS_DWORD)*MIN_PATTERN_SIZE)+new_offset),\
+                                    (shm_mem_ea + (rc-1)*(width)+new_offset),\
+                                    *(unsigned char*)(shm_mem_ea + ( rc-1)*(width)+new_offset));
+                            break;
+                        }
+            }
+            
+             strcat(msg_text,msg_temp); 
+            /* If pattern is RANDOM cannot generate dumps and
+             * If operation is RIM it does write and read compare immediately so cannot dump buffer files
+             */
+            if ((g_data.stanza_ptr->pattern_type[pi] != PATTERN_RANDOM ) && (g_data.stanza_ptr->operation != OPER_RIM )) {
+                page_offset = (rc-1)*width;/* Offset of miscompare in bytes */
+                new_offset = new_offset + (page_offset/(4*KB))*(4*KB); /* The 4k page aligned offset in bytes */
+                page_offset &= 0xfff;
+     
+                tmp_shm_size = local_ptr->seg_details[seg].shm_size - new_offset; /* Size of the remaining segment to be compared now */
+                if (ps == PAGE_INDEX_16G ) {
+                    tmp_shm_size = tmp_shm_size % sd->sub_seg_size;
+                }
+                /* Size of the page=4096. If it is last page, it can be less */
+                buffer_size = (tmp_shm_size>=(4*KB)) ? (4*KB):tmp_shm_size;
+                sprintf(fname,"%s/hxemem.%s.shmem.%d.%d_addr_0x%016lx_offset_%d",g_data.htx_d.htx_exer_log_dir,g_data.stanza_ptr->rule_id,\
+                    main_misc_count,miscompare_count,(unsigned long)(shm_mem_ea+new_offset), page_offset);
+
+                displaym(HTX_HE_SOFT_ERROR, DBG_MUST_PRINT, "miscompare file name = %s\n",fname);
+
+                 if( (main_misc_count<11) && (miscompare_count < 10)) {   /* Number of miscompares to be saved is 10 */
+                    sprintf(fname,"%s/hxemem.%s.shmem.%d.%d_addr_0x%016lx_offset_%d",g_data.htx_d.htx_exer_log_dir,g_data.stanza_ptr->rule_id,\
+                        main_misc_count,miscompare_count, (unsigned long )(shm_mem_ea+new_offset), page_offset);
+                    hxfsbuf((shm_mem_ea+new_offset),buffer_size, fname,&g_data.htx_d);       
+                    sprintf(msg_temp,"The miscomparing data in data buffer segment is in the file %s.\n",fname);
+                    strcat(msg_text,msg_temp); 
+                    sprintf(fname,"%s/hxemem.%s.pat.%d.%d_addr_0x%016lx_offset_%d",g_data.htx_d.htx_exer_log_dir,g_data.stanza_ptr->rule_id,\
+                        main_misc_count,miscompare_count, (unsigned long )(shm_mem_ea+new_offset), page_offset);
+                    sprintf(msg_temp,"The pattern data which is expected is in the file %s.\n",fname);
+                    strcat(msg_text,msg_temp);
+                    hxfsbuf(bit_pattern, MIN_PATTERN_SIZE, fname,&g_data.htx_d);
+                    miscompare_count++;
+                }
+                if(main_misc_count > 10) {
+                    sprintf(msg_temp,"Maximum number of miscompare buffers(10) have already been saved for this segment\n"
+                            " No Dump file correspoding to this miscompare will be found in %s  directory.\n",g_data.htx_d.htx_exer_log_dir);
+                    strcat(msg_text,msg_temp);
+                }
+                displaym(HTX_HE_SOFT_ERROR, DBG_MUST_PRINT, "%s",msg_text);
+
+                new_offset = new_offset +(4*KB);    /* Bytes already compared till now (4k page aligned) */
+                if (ps != PAGE_INDEX_16G) {
+                    if(new_offset >= local_ptr->seg_details[seg].shm_size)
+                        break;
+                } else {
+                    if(new_offset >= (sd->sub_seg_num+1)*sd->sub_seg_size)
+                        break;
+                }
+
+            } else { /* pattern_type == PATTERN_RANDOM */
+                page_offset = (rc-1)*width;/* Offset of miscompare in bytes */
+                new_offset = new_offset+page_offset+width;
+                sprintf(msg_temp,"PATTERN is RANDOM or it is a RIM Operation so hxemem64 is not generating dump.\n"
+                            "hxemem64 starts compare from the next dword/word/byte\n");
+                strcat(msg_text,msg_temp);
+                displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"%s\n",msg_text);
+                 miscompare_count++;
+            }
+            tmp_shm_size = local_ptr->seg_details[seg].shm_size - new_offset; /* Size of the remaining segment to be compared now */
+            if (ps == PAGE_INDEX_16G ) {
+                tmp_shm_size = tmp_shm_size % sd->sub_seg_size;
+            }
+
+            if (g_data.stanza_ptr->operation == OPER_STRIDE) {
+                return miscompare_count;
+            } else if ( g_data.stanza_ptr->operation != OPER_RIM ) {
+                rc = (*operation_fun_typ[g_data.stanza_ptr->pattern_type[pi]][COMPARE][mem_access_type_index])(
+                                                        (tmp_shm_size/sd->width),\
+                                                        (local_ptr->seg_details[seg].shm_mem_ptr + new_offset),\
+                                                        g_data.stanza_ptr->pattern[pi],\
+                                                        trap_flag,\
+                                                        sd,\
+                                                        g_data.stanza_ptr,\
+                                                        &g_data.stanza_ptr->pattern_size[pi],
+                                                        (unsigned long)seed_ptr);
+            }
+            else {/* RIM TEST CASE */
+                rc = (*operation_fun_typ[g_data.stanza_ptr->pattern_type[pi]][RIM][mem_access_type_index])(
+                                                        (tmp_shm_size/sd->width),\
+                                                        (local_ptr->seg_details[seg].shm_mem_ptr + new_offset),\
+                                                        g_data.stanza_ptr->pattern[pi],\
+                                                        trap_flag,\
+                                                        sd,\
+                                                        g_data.stanza_ptr,\
+                                                        &g_data.stanza_ptr->pattern_size[pi],
+                                                        (unsigned long)seed_ptr);
+            }
+            if (g_data.exit_flag == 1) {
+                return -1;
+            }
+
+            if(rc==0 || (miscompare_count == 11)) {
+                break;
+            }
+        } while(1);
+        return miscompare_count;
+    }
+    int get_mem_access_operation(int pat){
+       if(g_data.stanza_ptr->pattern_type[pat] == PATTERN_ADDRESS ) {
+           return DWORD;
+        }else {
+            if (g_data.stanza_ptr->width == LS_DWORD) return DWORD;
+            else if (g_data.stanza_ptr->width == LS_WORD)  return WORD;
+            else if (g_data.stanza_ptr->width == LS_BYTE)  return BYTE;
+            else{
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s: not supported load store width is passed, %d\n",
+                    __LINE__,__FUNCTION__,g_data.stanza_ptr->width);
+                exit(1);
+            }
+        }
+
+    }
+
+    int reset_segment_owners(){
+        int pi,n,seg;
+        struct chip_mem_pool_info *chip = &g_data.sys_details.chip_mem_pool_data[0];
+        struct mem_info *sys_mem_details = &g_data.sys_details.memory_details;
+        
+        if(g_data.gstanza.global_disable_filters == 0){
+            for(n = 0; n <g_data.sys_details.num_chip_mem_pools;n++){
+                if(!chip[n].has_cpu_and_mem)continue;
+                for(pi = 0;pi<MAX_PAGE_SIZES;pi++){
+                    for(seg=0;seg<chip[n].memory_details.pdata[pi].in_use_num_of_segments;seg++){
+                        if(chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].in_use){
+                            chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].owning_thread = -1;
+                            chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].in_use =0;
+                            chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].cpu_chip_num = -1;
+                        }	
+                    }
+                }
+            }
+        }else{
+            for(pi = 0;pi<MAX_PAGE_SIZES;pi++){
+                for(seg=0;seg< sys_mem_details->pdata[pi].in_use_num_of_segments;seg++){
+                    if(sys_mem_details->pdata[pi].page_wise_seg_data[seg].in_use){
+                        sys_mem_details->pdata[pi].page_wise_seg_data[seg].owning_thread = -1;
+                        sys_mem_details->pdata[pi].page_wise_seg_data[seg].in_use =0;
+                        sys_mem_details->pdata[pi].page_wise_seg_data[seg].cpu_chip_num = -1;
+                    }
+                }
+            }
+        }
+        return SUCCESS;
+    }
+    void release_thread_resources(int thread_num){
+
+        struct mem_exer_thread_info *local_ptr = (struct mem_exer_thread_info*)g_data.thread_ptr[thread_num].testcase_thread_details;
+        free(local_ptr->seg_details);
+
+    }
+    /*******************************************************************************************
+    *This function checks if the filesystem is located on RAM, if yes then dma_flag will be set*
+    *so that DMA case can be excluded in such case											   *
+    *******************************************************************************************/
+
+    int check_if_ramfs(void)
+    {
+        int filedes=0;
+        unsigned int mode_flag;
+        char pattern_nm[256];
+        char* pat_ptr = getenv("HTXPATTERNS");
+        mem_g.dma_flag = 0; /*intialize with zero*/
+        if(pat_ptr == NULL){
+            displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s(): env variable HTXPATTERNS is not set,pat_ptr=%p"
+            ", thus exiting..\n",__LINE__,__FUNCTION__,pat_ptr);
+            exit(1);
+        }else{
+            strcpy(pattern_nm,pat_ptr);
+        }
+        strcat(pattern_nm,"/HEXFF");
+        mode_flag = S_IWUSR | S_IWGRP | S_IWOTH;
+        errno = 0 ;
+
+        debug(HTX_HE_INFO, DBG_IMP_PRINT, "check_if_ramfs : Entered check_if_ramfs \n");
+        filedes = open(pattern_nm, O_DIRECT | O_RDONLY, mode_flag);
+        if ( errno == 22) {
+            displaym(HTX_HE_INFO, DBG_MUST_PRINT,"[%d]%s::open call returned with EINVAL(errno = %d).This can\
+                be because if filesystem is located on RAM,then  O_DIRECT flag is considered as invalid, in such case we will skip DMA test\
+                case. \n",__LINE__,__FUNCTION__,errno);
+
+             mem_g.dma_flag = 1;
+             errno = 0 ;
+        }
+
+        if(filedes > 0 ) {
+               debug(HTX_HE_INFO, DBG_IMP_PRINT, "check_if_ramfs : closing filedes = %d \n",filedes);
+               close (filedes);
+        }
+
+        return(SUCCESS);
+    }
+
+    #ifndef __HTX_LINUX__
+    int check_ame_enabled()
+    {
+        int rc = SUCCESS;
+        lpar_info_format2_t info;
+
+        rc = lpar_get_info(LPAR_INFO_FORMAT2, &info, sizeof(info));
+        if (rc) {
+            displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT, "[%d]%s:lpar_get_info failed with rc=%d,errno: %d\n", __LINE__,__FUNCTION__,rc,errno);
+            return (FAILURE);
+        }
+        if ((info.lpar_flags & LPAR_INFO2_AME_ENABLED) == LPAR_INFO2_AME_ENABLED) {
+            mem_g.AME_enabled = 1;
+        } else {
+            mem_g.AME_enabled = 0;
+        }
+        return rc;
+    }
+    #endif
+
+    /************************************************************************
+    *       SIGUSR2 signal handler for cpu hotplug add/remove               *
+    *************************************************************************/
+
+    #ifdef __HTX_LINUX__
+    void SIGUSR2_hdl(int sig, int code, struct sigcontext *scp)
+    {
+
+        g_data.stanza_ptr->disable_cpu_bind = 1;
+        cpu_add_remove_test = 1;
+        hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,"Recieved SIGUSR2 signal\n");
+    #if 0
+        int i, rc = 0;
+
+        if (mem_g.affinity == LOCAL ) {
+            /*for (i=0; i < mem_info.num_of_threads; i++) {
+                if (mem_info.tdata_hp[i].tid != -1) {
+                    rc = check_cpu_status_sysfs(mem_info.tdata_hp[i].physical_cpu);
+                    if (rc = 0) {
+                        displaym(HTX_HE_INFO,DBG_MUST_PRINT," cpu %d has been removed, thread:%d exiting in affinity yes case \n",mem_info.tdata_hp[i].physical_cpu,mem_info.tdata_hp[i].thread_num);
+                        pthread_cancel(mem_info.tdata_hp[i].tid);
+                    }
+                }
+            }*/
+            g_data.hotplug_flag= 1;
+        }
+        g_data.hotplug_flag = 1;
+    #endif
+    }
+    #endif
+
+    #ifdef    _DR_HTX_
+    void SIGRECONFIG_handler(int sig, int code, struct sigcontext *scp)
+    {
+        int rc;
+        char hndlmsg[512];
+        dr_info_t dr_info;          /* Info about DR operation, if any */
+        int i, bound_cpu;
+
+        /*sig_flag = 1;*/
+        hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,"DR: SIGRECONFIG signal received \n");
+
+        do {
+            rc = dr_reconfig(DR_QUERY,&dr_info);
+        } while ( rc < 0 && errno == EINTR);
+        if ( rc == -1) {
+            if ( errno != ENXIO){
+                hxfmsg(&g_data.htx_d,errno,HTX_HE_HARD_ERROR, "dr_reconfig(DR_QUERY) call failed. \n");
+            }
+            /*sig_flag = 0;*/
+            return;
+        }
+
+        if (dr_info.mem == 1){
+            sprintf(hndlmsg,"DR: DLPAR details"
+                "Phase - Check:  %d, Pre: %d, Post: %d, Post Error: %d\n"\
+                "Type - Mem add: %d remove: %d, ent_cap = %d, hibernate = %d \n",\
+                 dr_info.check, dr_info.pre, dr_info.post, dr_info.posterror, dr_info.add, dr_info.rem, dr_info.ent_cap, dr_info.hibernate);
+            hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,hndlmsg);
+        }
+
+        if (dr_info.cpu == 1 && (dr_info.rem || dr_info.add) ) {
+            sprintf(hndlmsg,"DR: DLPAR details"
+                "Phase - Check:  %d, Pre: %d, Post: %d, Post Error: %d\n"\
+                "Type - Cpu add: %d remove: %d, bcpu = %d \n",\
+                 dr_info.check, dr_info.pre, dr_info.post, dr_info.posterror, dr_info.add, dr_info.rem, dr_info.bcpu);
+            hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,hndlmsg);
+        }
+        if ( g_data.stanza_ptr == NULL ) {
+            g_data.stanza_ptr = &g_data.stanza[0];
+        }
+        /*
+         * Check-phase for CPU DR
+         * Handle only CPU removals, new CPUs will be used from the next stanza.
+         */
+        if (dr_info.check && dr_info.cpu && dr_info.rem) {
+
+            g_data.cpu_DR_flag = 1;
+            cpu_add_remove_test = 1;
+            /* Disable next binds and look for current bound cpu to thread,unbind it*/
+            g_data.stanza_ptr->disable_cpu_bind = 1;
+            if(g_data.thread_ptr != NULL){
+                for(i=0; i<g_data.stanza_ptr->num_threads; i++) {
+                    /* Also check if the running thread has already completed. */
+                    if ((g_data.thread_ptr[i].bind_proc == dr_info.bcpu) &&
+                        (g_data.thread_ptr[i].tid != -1)) {
+                        /* Unbind thread from the CPU under DR */
+                        if (bindprocessor(BINDTHREAD,g_data.thread_ptr[i].kernel_tid,
+                            PROCESSOR_CLASS_ANY)) {
+                            if (errno == ESRCH) {
+                                continue;
+                            }
+                            sprintf(hndlmsg,"Unbind failed. errno %d(%s), for thread num %d,cpu=%d"
+                                    ", TID %d.\n", errno,strerror(errno),i,g_data.thread_ptr[i].bind_proc,g_data.thread_ptr[i].tid);
+                            hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,hndlmsg);
+                        }
+                        /*
+                         * More than one thread could be bound to the same CPU.
+                         * as bind_proc = bind_proc%get_num_of_proc()
+                         * Run through all the threads, don't break the loop.
+                         */
+                    }
+                }
+            }
+            sprintf(hndlmsg,"DR: In check phase and cpu:%d is removed, we unbind threads which are affectd\n",dr_info.bcpu);
+            hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,hndlmsg);
+
+            if (dr_reconfig(DR_RECONFIG_DONE,&dr_info)){
+                sprintf(hndlmsg,"dr_reconfig(DR_RECONFIG_DONE) failed."
+                        " error %d \n", errno);
+                hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,hndlmsg);
+            }
+            else{
+                sprintf(hndlmsg,"DR:DR_RECONFIG_DONE Success!!,in check phase for cpu=%d \n",dr_info.bcpu);
+                hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,hndlmsg);
+
+            }
+            /*sig_flag = 0;*/
+            return;
+        }
+        /* Post/error phase; reset tracker count  */
+        if ((dr_info.post || dr_info.posterror) && dr_info.cpu && dr_info.rem) {
+            g_data.cpu_DR_flag = 0;  /*falg is set to recollect cpu details for tlbie test case*/
+        }
+
+        /* For any other signal check/Pre/Post-phase, respond with DR_RECONFIG_DONE */
+        if (dr_info.check || dr_info.pre || dr_info.post ) {
+            if (dr_info.mem && dr_info.check) {
+                sprintf(hndlmsg,"DR:Mem DR operation performed,setting  g_data.mem_DR_flag = 1");
+                hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,hndlmsg);
+                g_data.mem_DR_flag = 1;
+            }
+            if (dr_reconfig(DR_RECONFIG_DONE,&dr_info)){
+                sprintf(hndlmsg,"dr_reconfig(DR_RECONFIG_DONE) failed."
+                        " error %d ,check=%d,pre=%d,post=%d\n",dr_info.check,dr_info.pre,dr_info.post,errno);
+                hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,hndlmsg);
+            }
+            else{
+                sprintf(hndlmsg,"DR:DR_RECONFIG_DONE Successfully after check=%d, pre=%d, post=%d   phhase !! \n",dr_info.check,dr_info.pre,dr_info.post);
+                hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,hndlmsg);
+            }
+        }
+        /*sig_flag = 0;*/
+        return;
+    }
+    #endif
+
+    void print_memory_allocation_seg_details(){
+        int pi,n;
+        char msg[4096],msg_temp[1024];
+
+        sprintf(msg,"=======rule id:%s, Mem segment details*========\n"
+            "In rule file:alloc_mem_percent=%u, alloc_segment_size=%ld KB\n",
+            g_data.stanza_ptr->rule_id,g_data.gstanza.global_alloc_mem_percent,(g_data.gstanza.global_alloc_segment_size/ KB));
+        if(g_data.gstanza.global_disable_filters == 1){
+            for(pi = 0;pi<MAX_PAGE_SIZES;pi++){
+                if(!g_data.sys_details.memory_details.pdata[pi].supported)continue;
+                unsigned long long mem = ((pi < PAGE_INDEX_2M) ?
+                    (g_data.gstanza.global_alloc_mem_percent/100.0) * g_data.sys_details.memory_details.pdata[pi].free :
+                    g_data.sys_details.memory_details.pdata[pi].free);
+                sprintf(msg_temp,"\n\tpage size:%s\t mem:%llu MB\t total segments=%d\n",
+                    page_size_name[pi],(mem/MB),g_data.sys_details.memory_details.pdata[pi].num_of_segments);
+                strcat(msg,msg_temp);
+			if(g_data.sys_details.memory_details.pdata[pi].page_wise_usage_mem > 0){
+				sprintf(msg_temp,"\tIn use mem details:\n\tmem = %llu MB\t"
+					"\tnum_segs:%d\n",(g_data.sys_details.memory_details.pdata[pi].page_wise_usage_mem/MB)
+					,g_data.sys_details.memory_details.pdata[pi].in_use_num_of_segments);	
+				strcat(msg,msg_temp);
+			}
+		}
+	}else{	
+		for(n = 0; n <g_data.sys_details.num_chip_mem_pools;n++){
+			if(!g_data.sys_details.chip_mem_pool_data[n].has_cpu_and_mem)continue;
+			sprintf(msg_temp,"Chip[%d]:cpus:%d\n",n,g_data.sys_details.chip_mem_pool_data[n].num_cpus);
+			strcat(msg,msg_temp);
+			if(g_data.sys_details.chip_mem_pool_data[n].in_use_num_cpus > 0){
+				sprintf(msg_temp,"\tIn use cpus: %d,\t",g_data.sys_details.chip_mem_pool_data[n].in_use_num_cpus);
+				strcat(msg,msg_temp);
+				if(g_data.sys_details.chip_mem_pool_data[n].in_use_num_cpus != g_data.sys_details.chip_mem_pool_data[n].num_cpus){
+					for(int i=0;i<g_data.sys_details.chip_mem_pool_data[n].in_use_num_cpus;i++){
+						sprintf(msg_temp,":%d",g_data.sys_details.chip_mem_pool_data[n].in_use_cpulist[i]);
+						strcat(msg,msg_temp);
+					}
+				}
+			}
+			for(pi = 0;pi<MAX_PAGE_SIZES;pi++){
+				if(!g_data.sys_details.chip_mem_pool_data[n].memory_details.pdata[pi].supported)continue;
+				unsigned long long mem = ((pi < PAGE_INDEX_2M) ? 
+					(g_data.gstanza.global_alloc_mem_percent/100.0) * g_data.sys_details.chip_mem_pool_data[n].memory_details.pdata[pi].free :
+					g_data.sys_details.chip_mem_pool_data[n].memory_details.pdata[pi].free);
+				sprintf(msg_temp,"\n\tpage size:%s\t mem:%llu MB\t total segments=%d\n",
+					page_size_name[pi],(mem/MB),g_data.sys_details.chip_mem_pool_data[n].memory_details.pdata[pi].num_of_segments);
+				strcat(msg,msg_temp); 
+				if(g_data.sys_details.chip_mem_pool_data[n].memory_details.pdata[pi].page_wise_usage_mem > 0){
+					sprintf(msg_temp,"\tIn use mem details:\n\tmem = %llu MB\t"
+						"\tnum_segs:%d\n",(g_data.sys_details.chip_mem_pool_data[n].memory_details.pdata[pi].page_wise_usage_mem/MB)
+						,g_data.sys_details.chip_mem_pool_data[n].memory_details.pdata[pi].in_use_num_of_segments);
+					strcat(msg,msg_temp);
+				}
+			}
+		}   
+	}
+    displaym(HTX_HE_INFO,DBG_MUST_PRINT,"%s\n",msg);
+}
+
+int log_mem_seg_details(){
+    
+    char dump_file[100];
+    FILE *fp;
+    struct chip_mem_pool_info *chip = &g_data.sys_details.chip_mem_pool_data[0];
+	struct mem_info* sys_mem_details = &g_data.sys_details.memory_details;
+    int n,pi,seg,bind_cpu = -1;
+    char temp_str[100];
+    if(g_data.gstanza.global_disable_filters == 0){
+        sprintf(temp_str,"CHIP LEVEL MEMORY EXERCISE");
+    }else{
+        sprintf(temp_str,"SYSTEM VIEW MEMORY EXERCISE,NO STRICT AFFINITY MAINTAINED");
+    }
+    sprintf(dump_file, "%s/mem_segment_details",g_data.htx_d.htx_exer_log_dir);
+
+    fp = fopen(dump_file, "w");
+    if ( fp == NULL) {
+        displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"[%d]%s():Error opening %s file,errno:%d(%s),continuing without debug log file \n"
+            ,__LINE__,__FUNCTION__,dump_file,errno,strerror(errno));
+        return (FAILURE);
+    }
+    fprintf(fp, "STANZA:rule_id = %s, %s\n",g_data.stanza_ptr->rule_id,temp_str);
+    fprintf(fp,"***************************************************************************"
+                "***************************************************************************\n");
+    fprintf(fp," In_use_seg_num\t page_size\tOwning_thread\tcpu_num \tmem_chip_num\t segment_id \t\t segment_size \t\t segment_EA\n");
+	if(g_data.gstanza.global_disable_filters == 0){
+		for(n = 0; n <g_data.sys_details.num_chip_mem_pools;n++){
+			if(!chip[n].has_cpu_and_mem)continue;
+			fprintf(fp,"========================================================================"
+						"========================================================================\n");
+			for(pi = 0;pi<MAX_PAGE_SIZES;pi++){
+				for(seg=0;seg<chip[n].memory_details.pdata[pi].in_use_num_of_segments;seg++){
+					if(!chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].in_use)continue;
+						if(g_data.stanza_ptr->disable_cpu_bind == 0 && chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].owning_thread != -1){
+							bind_cpu = g_data.thread_ptr[chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].owning_thread].bind_proc;
+						}
+						fprintf(fp," \t%lu \t %s \t\t %d \t\t %d \t\t %d \t\t %lu \t\t %lu \t\t 0x%llx\n",
+							chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].seg_num,page_size_name[pi],
+							chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].owning_thread,
+							bind_cpu,
+							chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].mem_chip_num,
+							chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].shmid,
+							chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].shm_size,
+							chip[n].memory_details.pdata[pi].page_wise_seg_data[seg].shm_mem_ptr);
+				}
+			}
+		}
+	}else{
+		fprintf(fp,"========================================================================"
+					"========================================================================\n");
+		for(pi = 0;pi<MAX_PAGE_SIZES;pi++){
+			for(seg=0;seg<sys_mem_details->pdata[pi].in_use_num_of_segments;seg++){
+				if(!sys_mem_details->pdata[pi].page_wise_seg_data[seg].in_use)continue;
+					if(g_data.stanza_ptr->disable_cpu_bind == 0 && sys_mem_details->pdata[pi].page_wise_seg_data[seg].owning_thread != -1){
+						bind_cpu = g_data.thread_ptr[sys_mem_details->pdata[pi].page_wise_seg_data[seg].owning_thread].bind_proc;
+					}
+					fprintf(fp," \t%lu \t %s \t\t %d \t\t %d \t\t %d \t\t %lu \t\t %lu \t\t 0x%llx\n",
+						sys_mem_details->pdata[pi].page_wise_seg_data[seg].seg_num,page_size_name[pi],
+						sys_mem_details->pdata[pi].page_wise_seg_data[seg].owning_thread,
+						bind_cpu,
+						sys_mem_details->pdata[pi].page_wise_seg_data[seg].mem_chip_num,
+						sys_mem_details->pdata[pi].page_wise_seg_data[seg].shmid,
+						sys_mem_details->pdata[pi].page_wise_seg_data[seg].shm_size,
+						sys_mem_details->pdata[pi].page_wise_seg_data[seg].shm_mem_ptr);
+			}
+		}
+	}
+	fprintf(fp,"****************************************************************************"
+                "****************************************************************************\n");
+    fclose(fp);
+    return SUCCESS;
+}

--- a/bin/hxemem64/mem_pattern_file_operations.c
+++ b/bin/hxemem64/mem_pattern_file_operations.c
@@ -1,0 +1,258 @@
+/* IBM_PROLOG_BEGIN_TAG */
+/*
+ * Copyright 2003,2016 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "nest_framework.h"
+
+#ifdef __HTX_LINUX__
+#define dcbf(x) __asm ("dcbf 0,%0\n\t": : "r" (x))
+#else
+#pragma mc_func dcbf    { "7C0018AC" }          /* dcbf r3 */
+#endif
+
+int pat_operation_write_dword(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed) {
+    int i=0,rc=0,pat_itr=0;
+    unsigned int  pat_size = *(unsigned int*)pattern_sz_ptr;
+    unsigned long *rw_ptr          = (unsigned long *)seg_address;
+    unsigned long *loc_pattern_ptr = (unsigned long *)pattern_ptr;
+    unsigned int pat_limit    = pat_size/8;
+
+    for (i=0; i < num_operations/pat_limit; i++) {
+        for(pat_itr=0;pat_itr < pat_limit;pat_itr++){
+            *rw_ptr         = *(unsigned long *)loc_pattern_ptr;
+            rw_ptr         = rw_ptr + 1;
+            loc_pattern_ptr = loc_pattern_ptr +1;
+        }
+        loc_pattern_ptr = (unsigned long *)pattern_ptr;
+    }
+    return (rc);
+}
+
+int pat_operation_write_word(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed) {
+
+    int i=0,rc=0,pat_itr=0;
+    unsigned int  pat_size = *(unsigned int*)pattern_sz_ptr;
+    unsigned int *rw_ptr          = (unsigned int*)seg_address;
+    unsigned int *loc_pattern_ptr = (unsigned int*)pattern_ptr;
+    unsigned int pat_limit    = pat_size/8;
+
+    for (i=0; i < num_operations/pat_limit; i++) {
+        for(pat_itr=0;pat_itr < pat_limit;pat_itr++){
+            *rw_ptr         = *(unsigned int*)loc_pattern_ptr;
+            rw_ptr         = rw_ptr + 1;
+            loc_pattern_ptr = loc_pattern_ptr +1;
+        }
+        loc_pattern_ptr = (unsigned int*)pattern_ptr;
+    }
+    return (rc);
+}
+
+int pat_operation_write_byte(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed) {
+
+    int i=0,rc=0,pat_itr=0;
+    unsigned int  pat_size = *(unsigned int*)pattern_sz_ptr;
+    char *rw_ptr          = (char*)seg_address;
+    char *loc_pattern_ptr = (char*)pattern_ptr;
+    unsigned int pat_limit    = pat_size/8;
+
+    for (i=0; i < num_operations/pat_limit; i++) {
+        for(pat_itr=0;pat_itr < pat_limit;pat_itr++){
+            *rw_ptr         = *(char*)loc_pattern_ptr;
+            rw_ptr         = rw_ptr + 1;
+            loc_pattern_ptr = loc_pattern_ptr +1;
+        }
+        loc_pattern_ptr = (char*)pattern_ptr;
+    }
+    return (rc);
+}
+int pat_operation_comp_dword(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed) {
+
+    int i=0,rc=0,pat_itr=0;
+    unsigned int  pat_size = *(unsigned int*)pattern_sz_ptr;
+    unsigned long *ptr = (unsigned long *)seg_address, *loc_pattern_ptr = (unsigned long *)pattern_ptr;
+    unsigned int pat_limit    = pat_size/8;
+    
+    for (i=0; i < num_operations/pat_limit; i++) {
+        for(pat_itr=0;pat_itr < pat_limit;pat_itr++){
+            if(*ptr != *loc_pattern_ptr) {
+                if(trap_flag){
+                    #ifndef __HTX_LINUX__
+                    trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                    #else
+                    do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                    #endif
+                }
+                rc = i+1;
+                return (rc);
+            }
+            loc_pattern_ptr = loc_pattern_ptr + 1;
+            ptr             = ptr + 1;
+        }
+        loc_pattern_ptr = (unsigned long *)pattern_ptr;
+    }
+    return (rc);
+}
+        
+int pat_operation_comp_word(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed) {
+
+    int i=0,rc=0,pat_itr=0;
+    unsigned int  pat_size = *(unsigned int*)pattern_sz_ptr;
+    unsigned int *ptr = (unsigned int*)seg_address, *loc_pattern_ptr = (unsigned int*)pattern_ptr;
+    unsigned int pat_limit    = pat_size/8;
+
+    for (i=0; i < num_operations/pat_limit; i++) {
+        for(pat_itr=0;pat_itr < pat_limit;pat_itr++){
+            if(*ptr != *loc_pattern_ptr) {
+                if(trap_flag){
+                    #ifndef __HTX_LINUX__
+                    trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                    #else
+                    do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                    #endif
+                }
+                rc = i+1;
+                return (rc);
+            }
+            loc_pattern_ptr = loc_pattern_ptr + 1;
+            ptr             = ptr + 1;
+        }
+        loc_pattern_ptr = (unsigned int*)pattern_ptr;
+    }
+    return (rc);
+}
+
+int pat_operation_comp_byte(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed) {
+
+    int i=0,rc=0,pat_itr=0;
+    unsigned int  pat_size = *(unsigned int*)pattern_sz_ptr;
+    char *ptr = (char *)seg_address, *loc_pattern_ptr = (char*)pattern_ptr;
+    unsigned int pat_limit    = pat_size/8;
+
+    for (i=0; i < num_operations/pat_limit; i++) {
+        for(pat_itr=0;pat_itr < pat_limit;pat_itr++){
+            if(*ptr != *loc_pattern_ptr) {
+                if(trap_flag){
+                    #ifndef __HTX_LINUX__
+                    trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                    #else
+                    do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                    #endif
+                }
+                rc = i+1;
+                return (rc);
+            }
+            loc_pattern_ptr = loc_pattern_ptr + 1;
+            ptr             = ptr + 1;
+        }
+        loc_pattern_ptr = (char*)pattern_ptr;
+    }
+    return (rc);
+}
+
+int  pat_operation_rim_dword(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0,pat_itr=0;
+    unsigned int  pat_size = *(unsigned int*)pattern_sz_ptr;
+    unsigned long *w_ptr = (unsigned long *)seg_address, *loc_pattern_ptr = (unsigned long *)pattern_ptr;
+    unsigned long read_dw_data;
+    unsigned int pat_limit    = pat_size/8;
+    for (i=0; i < num_operations/pat_limit; i++) {
+        for(pat_itr=0;pat_itr < pat_limit;pat_itr++){
+            *w_ptr = *(unsigned long *)loc_pattern_ptr;
+            read_dw_data = *(unsigned long *)w_ptr;
+            dcbf((volatile unsigned long*)w_ptr);
+            read_dw_data = *(unsigned long *)w_ptr;
+            if(read_dw_data != *(unsigned long *)loc_pattern_ptr) {
+                if(trap_flag){
+                    #ifndef __HTX_LINUX__
+                    trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                    #else
+                    do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)w_ptr,(unsigned long)seg,stanza);
+                    #endif
+                }
+                rc = i+1;
+                return (rc);
+            }
+            w_ptr = w_ptr + 1;
+            loc_pattern_ptr = loc_pattern_ptr + 1;
+        }
+        loc_pattern_ptr = (unsigned long *)pattern_ptr;
+    }
+    return (rc);
+}
+
+int pat_operation_rim_word(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0,pat_itr=0;
+    unsigned int  pat_size = *(unsigned int*)pattern_sz_ptr;
+    unsigned int *w_ptr = (unsigned int*)seg_address, *loc_pattern_ptr = (unsigned int*)pattern_ptr;
+    unsigned int read_dw_data;
+    unsigned int pat_limit    = pat_size/8;
+    for (i=0; i < num_operations/pat_limit; i++) {
+        for(pat_itr=0;pat_itr < pat_limit;pat_itr++){
+            *w_ptr = *(unsigned int*)loc_pattern_ptr;
+            read_dw_data = *(unsigned int*)w_ptr;
+            dcbf((volatile unsigned int*)w_ptr);
+            read_dw_data = *(unsigned int*)w_ptr;
+            if(read_dw_data != *(unsigned int*)loc_pattern_ptr) {
+                if(trap_flag){
+                    #ifndef __HTX_LINUX__
+                    trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                    #else
+                    do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                    #endif
+
+                }
+                rc = i+1;
+                return (rc);
+            }
+            w_ptr = w_ptr + 1;
+            loc_pattern_ptr = loc_pattern_ptr + 1;
+        }
+        loc_pattern_ptr = (unsigned int*)pattern_ptr;
+    }
+    return (rc);
+}
+
+int pat_operation_rim_byte(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0,pat_itr=0;
+    unsigned int  pat_size = *(unsigned int*)pattern_sz_ptr;
+    char *w_ptr = (char*)seg_address, *loc_pattern_ptr = (char*)pattern_ptr;
+    char read_dw_data;
+    unsigned int pat_limit    = pat_size/8;
+    for (i=0; i < num_operations/pat_limit; i++) {
+        for(pat_itr=0;pat_itr < pat_limit;pat_itr++){
+            *w_ptr = *(char*)loc_pattern_ptr;
+            read_dw_data = *(char*)w_ptr;
+            dcbf((volatile char*)w_ptr);
+            read_dw_data = *(char*)w_ptr;
+            if(read_dw_data != *(char*)loc_pattern_ptr) {
+                if(trap_flag){
+                    #ifndef __HTX_LINUX__
+                    trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                    #else
+                    do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                    #endif
+                }
+                rc = i+1;
+                return (rc);
+            }
+            w_ptr = w_ptr + 1;
+            loc_pattern_ptr = loc_pattern_ptr + 1;
+        }
+        loc_pattern_ptr = (char*)pattern_ptr;
+    }
+    return (rc);
+}
+

--- a/bin/hxemem64/mem_random_pat_operations.c
+++ b/bin/hxemem64/mem_random_pat_operations.c
@@ -1,0 +1,264 @@
+/* IBM_PROLOG_BEGIN_TAG */
+/*
+ * Copyright 2003,2016 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "nest_framework.h"
+
+#ifdef __HTX_LINUX__
+#define dcbf(x) __asm ("dcbf 0,%0\n\t": : "r" (x))
+#else
+#pragma mc_func dcbf    { "7C0018AC" }          /* dcbf r3 */
+#endif
+
+unsigned char get_random_no_8(unsigned long *lseed)
+{
+    unsigned char r_num;
+    long int tmp = rand_r((unsigned int*)lseed);
+    r_num = (unsigned char)(tmp % 255);
+    return r_num;
+}
+
+unsigned int get_random_no_32(unsigned long *lseed)
+{
+    unsigned int r_num = rand_r((unsigned int*)lseed);
+    return r_num;
+}
+
+unsigned long get_random_no_64(unsigned long *lseed) {
+
+    long int tmp;
+    unsigned long r_num;
+    tmp = rand_r((unsigned int*)lseed);
+    *lseed = tmp;
+    r_num = ((unsigned long) tmp << 32);
+    r_num |= rand_r((unsigned int*)lseed);
+    return r_num;
+}
+
+int rand_operation_write_dword(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned long *rw_ptr = (unsigned long *)seg_address;
+    unsigned long *lseed      = (unsigned long *)seed;
+    unsigned long rand_no;
+    for (i=0;i<num_operations;i++){
+        rand_no = get_random_no_64(lseed);
+        *rw_ptr = rand_no;
+        rw_ptr = rw_ptr + 1;
+        *lseed = (unsigned long)rand_no;
+    }
+    *(unsigned long*)seed = (unsigned long) rand_no;
+    rc = 0;
+    return (rc);
+}
+
+int rand_operation_write_word(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned int *rw_ptr = (unsigned int*)seg_address;
+    unsigned long *lseed      = (unsigned long*)seed;
+    unsigned int rand_no = *(unsigned long*)seed;
+    for (i=0;i<num_operations;i++){
+        rand_no = get_random_no_32(lseed);
+        *rw_ptr = rand_no;
+        rw_ptr = rw_ptr + 1;
+        *lseed = (unsigned long)rand_no;
+    }
+    *(unsigned long*)seed = (unsigned long) rand_no;
+    rc = 0;
+    return (rc);
+}
+
+int rand_operation_write_byte(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned char *rw_ptr = (unsigned char*)seg_address;
+    unsigned long *lseed      = (unsigned long*)seed;
+    unsigned char rand_no; 
+    for (i=0;i<num_operations;i++){
+        rand_no = get_random_no_8(lseed);
+        *rw_ptr = rand_no;
+        rw_ptr = rw_ptr + 1;
+        *lseed = (unsigned long)rand_no;
+    }
+    *(unsigned long*)seed = (unsigned long) rand_no;
+    rc = 0;
+    return (rc);
+}
+
+int rand_operation_comp_dword(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned long *ptr   = (unsigned long *)seg_address;
+    unsigned long *lseed = (unsigned long *)seed;
+    unsigned long rand_no; 
+    for (i=0;i<num_operations;i++){
+        rand_no = get_random_no_64(lseed);
+        if(*ptr != rand_no) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)rand_no,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)rand_no,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+            rc = i+1;
+            break;
+        }
+        *(unsigned long*)lseed = (unsigned long)rand_no;
+        ptr = ptr + 1;
+        rc = 0;
+    }
+    *(unsigned long*)seed = (unsigned long)rand_no;
+    return rc;
+}
+
+int rand_operation_comp_word(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned int *ptr   = (unsigned int*)seg_address;
+    unsigned long *lseed = (unsigned long *)seed;
+    unsigned int rand_no = *(unsigned long*)seed;
+    for (i=0;i<num_operations;i++){
+        rand_no = get_random_no_32(lseed);
+        if(*ptr != rand_no) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long )rand_no,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)rand_no,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+            rc = i+1;
+            break;
+        }
+        *lseed = (unsigned long)rand_no;
+        ptr = ptr + 1;
+        rc = 0;
+    }
+    *(unsigned long*)seed = (unsigned long) rand_no;
+    return rc;
+}
+
+int rand_operation_comp_byte(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned char *ptr   = (unsigned char*)seg_address;
+    unsigned long *lseed = (unsigned long *)seed;
+    unsigned char rand_no = *(unsigned long*)seed;
+    for (i=0;i<num_operations;i++){
+        rand_no = get_random_no_8(lseed);
+        if(*ptr != rand_no) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)rand_no,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)rand_no,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+            rc = i+1;
+            break;
+        }
+        *lseed = (unsigned long)rand_no;
+        ptr = ptr + 1;
+        rc = 0;
+    }
+    *(unsigned long*)seed = (unsigned long) rand_no;
+    return rc;
+}
+
+int rand_operation_rim_dword(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned long  *w_ptr = (unsigned long *)seg_address;
+    unsigned long  *lseed = (unsigned long *)seed;
+    unsigned long rand_no = *(unsigned long*)seed,read_dw_data;
+    for (i=0;i < num_operations;i++){
+        rand_no = get_random_no_64(lseed);
+        *w_ptr = rand_no;
+        read_dw_data = *(unsigned long *)w_ptr;
+        dcbf((volatile unsigned long*)w_ptr);
+        if(read_dw_data != rand_no) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)rand_no,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)rand_no,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+
+            }
+            rc = i+1;
+            break;
+        }
+        *lseed = (unsigned long)rand_no;
+        w_ptr = w_ptr + 1;
+        rc = 0;
+    }
+    *(unsigned long*)seed = (unsigned long) rand_no;
+    return rc;
+}
+
+int rand_operation_rim_word(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned int *w_ptr = (unsigned int*)seg_address;
+    unsigned long *lseed = (unsigned long *)seed;
+    unsigned int rand_no = *(unsigned long*)seed,read_data;
+    for (i=0;i < num_operations;i++){
+        rand_no = get_random_no_32(lseed);
+        *w_ptr = rand_no;
+        read_data = *(unsigned int*)w_ptr;
+        dcbf((volatile unsigned int*)w_ptr);
+        if(read_data != rand_no) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long *)seg_address,(unsigned long)rand_no,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)rand_no,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+            rc = i+1;
+            break;
+        }
+        *lseed = (unsigned long)rand_no;
+        w_ptr = w_ptr + 1;
+        rc = 0;
+    }
+    *(unsigned long*)seed = (unsigned long) rand_no;
+    return rc;
+}
+
+int rand_operation_rim_byte(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned char *w_ptr = (unsigned char*)seg_address;
+    unsigned long *lseed = (unsigned long *)seed;
+    unsigned char rand_no= *(unsigned long*)seed,read_data;
+    for (i=0;i < num_operations;i++){
+        rand_no = get_random_no_8(lseed);
+        *w_ptr = rand_no;
+        read_data = *(unsigned char*)w_ptr;
+        dcbf((volatile unsigned char*)w_ptr);
+        if(read_data != rand_no) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)rand_no,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)rand_no,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+            rc = i+1;
+            break;
+        }
+        *lseed = (unsigned long)rand_no;
+        w_ptr = w_ptr + 1;
+        rc = 0;
+    }
+    *(unsigned long*)seed = (unsigned long) rand_no;
+    return rc;
+}
+

--- a/bin/hxemem64/memory_operations.c
+++ b/bin/hxemem64/memory_operations.c
@@ -1,0 +1,305 @@
+/* IBM_PROLOG_BEGIN_TAG */
+/*
+ * Copyright 2003,2016 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "nest_framework.h"
+#ifdef __HTX_LINUX__
+#define dcbf(x) __asm ("dcbf 0,%0\n\t": : "r" (x))
+#else
+#pragma mc_func dcbf    { "7C0018AC" }          /* dcbf r3 */
+#endif
+extern struct mem_exer_info mem_g;
+
+int mem_operation_write_dword(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned long *rw_ptr = (unsigned long *)seg_address;
+    for (i=0; i < num_operations; i++) {
+        *rw_ptr = *(unsigned long *)pattern_ptr;
+        rw_ptr = rw_ptr + 1;
+    }
+    rc = 0;
+    return (rc);
+
+}
+
+int mem_operation_write_word(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned int *rw_ptr = (unsigned int *)seg_address;
+    for (i=0; i < num_operations; i++) {
+        *rw_ptr = *(unsigned int*)pattern_ptr;
+        rw_ptr = rw_ptr + 1;
+    }
+    rc = 0;
+    return (rc);
+
+}
+int mem_operation_write_byte(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned char *rw_ptr = (unsigned char *)seg_address;
+    for (i=0; i < num_operations; i++) {
+        *rw_ptr = *(unsigned char*)pattern_ptr;
+        rw_ptr = rw_ptr + 1;
+    }
+    rc = 0;
+    return (rc);
+
+}
+int mem_operation_read_dword(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    volatile unsigned long *rw_ptr = (unsigned long *)seg_address;
+    unsigned long consume_data=0;
+    unsigned long read_data;
+    for (i=0; i < num_operations; i++) {
+        read_data = *(unsigned long *)rw_ptr;
+        consume_data += (read_data+i);/*to avoide compiler optimization*/
+        rw_ptr = rw_ptr + 1;
+    }
+    mem_g.dummy_read_data = consume_data;/*to avoide compiler optimization*/
+    rc = 0;
+    return (rc);
+}
+
+int mem_operation_read_word(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    volatile unsigned int *rw_ptr = (unsigned int *)seg_address;
+    unsigned long consume_data=0;
+    unsigned int read_data;
+    for (i=0; i < num_operations; i++) {
+        read_data = *(unsigned int *)rw_ptr;
+        consume_data += (read_data+i);/*to avoide compiler optimization*/
+        rw_ptr = rw_ptr + 1; 
+    }
+    mem_g.dummy_read_data = consume_data;/*to avoide compiler optimization*/
+    rc = 0;
+    return (rc);
+}
+int mem_operation_read_byte(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    volatile unsigned char *rw_ptr = (unsigned char *)seg_address;
+    unsigned long consume_data=0;
+    unsigned char read_data;
+    for (i=0; i < num_operations; i++) {
+        read_data = *(unsigned char *)rw_ptr;
+        consume_data += (read_data+i);/*to avoide compiler optimization*/
+        rw_ptr = rw_ptr + 1; 
+    }
+    mem_g.dummy_read_data = consume_data;/*to avoide compiler optimization*/
+    rc = 0;
+    return (rc);
+}
+int mem_operation_comp_dword(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    volatile unsigned long *ptr = (unsigned long *)seg_address, *loc_pattern_ptr = (unsigned long *)pattern_ptr;
+    int i=0,rc=0;
+    for (i=0; i < num_operations; i++) {
+        if(*ptr != *loc_pattern_ptr) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+            rc = i+1;
+            break;
+        }
+        ptr = ptr + 1;
+        rc = 0;
+    } 
+    return rc;
+}
+int mem_operation_comp_word(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    volatile unsigned int *ptr = (unsigned int *)seg_address, *loc_pattern_ptr = (unsigned int *)pattern_ptr;
+    int i=0,rc=0;
+    for (i=0; i < num_operations; i++) {
+        if(*ptr != *loc_pattern_ptr) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+            rc = i+1;
+            break;
+        }
+        ptr = ptr + 1;
+        rc = 0;
+    } 
+    return rc;
+}
+int mem_operation_comp_byte(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    volatile unsigned char *ptr = (unsigned char *)seg_address, *loc_pattern_ptr = (unsigned char *)pattern_ptr;
+    int i=0,rc=0;
+    for (i=0; i < num_operations; i++) {
+        if(*ptr != *loc_pattern_ptr) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+            rc = i+1;
+            break;
+        }
+        ptr = ptr + 1;
+        rc = 0;
+    } 
+    return rc;
+}
+
+int mem_operation_write_addr(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned long address = *(unsigned long *)seg_address;
+    unsigned long *rw_ptr = (unsigned long *)seg_address;
+    for (i=0; i < num_operations; i++) {
+        *rw_ptr = address;
+        rw_ptr = rw_ptr + 1;
+        address = (unsigned long)rw_ptr;
+    }
+    rc = 0;
+    return (rc);
+}
+
+int mem_operation_comp_addr(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned long *ptr = (unsigned long *)seg_address ;
+    unsigned long address = *(unsigned long *)seg_address;
+    for (i=0; i < num_operations; i++) {
+        if(*ptr != address) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+            rc = i+1;
+            break;
+        }
+        ptr = ptr + 1;
+        address = ptr;
+        rc = 0;
+    }
+    return rc;
+}
+int  mem_operation_rim_dword(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned long *w_ptr = (unsigned long *)seg_address;
+    unsigned long read_data;
+    for (i=0; i < num_operations; i++) {
+        *w_ptr = *(unsigned long *)pattern_ptr;
+        read_data = *(unsigned long *)w_ptr;
+        dcbf((volatile unsigned long*)w_ptr);
+        read_data = *(unsigned long *)w_ptr;
+        if(read_data != *(unsigned long *)pattern_ptr) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+            rc = i+1;
+            break;
+        }
+        w_ptr = w_ptr + 1;
+        rc = 0;
+    }
+    return rc;
+}
+int  mem_operation_rim_word(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned int *w_ptr = (unsigned int*)seg_address;
+    unsigned int read_data;
+    for (i=0; i < num_operations; i++) {
+        *w_ptr = *(unsigned int*)pattern_ptr;
+        read_data = *(unsigned int*)w_ptr;
+        dcbf((volatile unsigned int*)w_ptr);
+        read_data = *(unsigned int*)w_ptr;
+        if(read_data != *(unsigned int*)pattern_ptr) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+
+            rc = i+1;
+            break;
+        }
+        w_ptr = w_ptr + 1;
+        rc = 0;
+    }
+    return rc;
+}
+
+int  mem_operation_rim_byte(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    char *w_ptr = (unsigned char*)seg_address;
+    char read_data;
+    for (i=0; i < num_operations; i++) {
+        *w_ptr = *(char*)pattern_ptr;
+        read_data = *(char*)w_ptr;
+        dcbf((volatile char*)w_ptr);
+        read_data = *(char*)w_ptr;
+        if(read_data != *(char*)pattern_ptr) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)w_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+
+            rc = i+1;
+            break;
+        }
+        w_ptr = w_ptr + 1;
+        rc = 0;
+    }
+    return rc;
+}
+
+int mem_operation_write_addr_comp(int num_operations,void *seg_address,void *pattern_ptr,int trap_flag,void *seg,void *stanza,void *pattern_sz_ptr,void* seed){
+    int i=0,rc=0;
+    unsigned long *rw_ptr = (unsigned long *)seg_address;
+    unsigned long address = *(unsigned long *)seg_address;
+    unsigned long read_dw_data;
+    for (i=0;i<num_operations;i++){
+        *rw_ptr = address;
+        dcbf((volatile unsigned long*)rw_ptr);
+        read_dw_data = *(unsigned long *)rw_ptr;
+        if(read_dw_data != address) {
+            if(trap_flag){
+                #ifndef __HTX_LINUX__
+                trap(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)rw_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #else
+                do_trap_htx64(0xBEEFDEAD,i,(unsigned long)seg_address,(unsigned long)pattern_ptr,(unsigned long)rw_ptr,(unsigned long)seg,(unsigned long)stanza);
+                #endif
+            }
+            rc = i+1;
+            break;
+        }
+        rw_ptr  = rw_ptr + 1;
+        address = rw_ptr;
+        rc = 0;
+    }
+    return rc;
+}
+
+

--- a/bin/hxemem64/nest_framework.c
+++ b/bin/hxemem64/nest_framework.c
@@ -1,0 +1,894 @@
+/* IBM_PROLOG_BEGIN_TAG */
+/*
+ * Copyright 2003,2016 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "nest_framework.h"
+#define DEBUG_ON
+
+
+/*move below global vars to mem specific file later*/
+int AME_enabled = FALSE;
+char  page_size_name[MAX_PAGE_SIZES][8]={"4K","64K","2M","16M","16G"};/*RV2:add new supported pages*/
+struct nest_global g_data;
+
+
+/*********************************************
+ * Function Prototypes						*
+ * ******************************************/
+#if 0
+void SIGCPUFAIL_handler(int,int, struct sigcontext *);
+void reg_sig_handlers(void);
+int read_cmd_line(int argc,char *argv[]); 
+void get_test_type(void);
+void get_cache_details(void);
+int get_system_details(void);
+int apply_process_settings(void);
+
+#ifdef __HTX_LINUX__
+extern void SIGUSR2_hdl(int, int, struct sigcontext *);
+#endif
+#endif
+/***********************************************************************
+ *
+* SIGTERM signal handler                                               *
+************************************************************************/
+ 
+void SIGTERM_hdl (int sig, int code, struct sigcontext *scp)
+{
+    /* Dont use display function inside signal handler.
+     * the mutex lock call will never return and process
+     * will be stuck in the display function */
+    hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,"hxemem64: Sigterm Received!\n");
+    g_data.exit_flag = 1;
+}
+void SIGSEGV_hdl(int sig, int code, struct sigcontext *scp)
+{
+    char msg[50];
+    hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,"hxemem64: sig11 Received!\n");
+     
+}
+
+
+
+#ifndef __HTX_LINUX__
+
+void SIGCPUFAIL_handler(int sig, int code, struct sigcontext *scp)
+{
+#if 0
+    char hndlmsg[512];
+    int no_of_proc;
+
+    hxfmsg(&g_data.htx_d,0,HTX_HE_INFO,"SIGCPUFAIL signal recieved.\n");
+
+    g_data.sigvector.sa_handler = (void (*)(int))SIG_IGN;
+    (void) sigaction(SIGCPUFAIL, &g_data.sigvector, (struct sigaction *) NULL);
+
+    no_of_proc = get_num_of_proc();
+    if (mem_info.tdata_hp[mem_info.num_of_threads - 1].thread_num == (no_of_proc - 1) && mem_info.tdata_hp[mem_info.num_of_threads - 1].tid != -1) {
+        if (bindprocessor(BINDTHREAD, mem_info.tdata_hp[mem_info.num_of_threads - 1].kernel_tid, PROCESSOR_CLASS_ANY)) {
+            sprintf(hndlmsg,"Unbind failed. errno %d, for thread num %d, TID %d.\n", errno, mem_info.num_of_threads - 1, mem_info.tdata_hp[mem_info.num_of_threads - 1].tid);
+        }
+    }
+    g_data.sigvector.sa_handler = (void (*)(int))SIGCPUFAIL_handler;
+    (void) sigaction(SIGCPUFAIL, &g_data.sigvector, (struct sigaction *) NULL);
+#endif
+	}
+#endif
+
+
+
+void reg_sig_handlers()
+{
+	/* SIGTERM handler registering */
+    sigemptyset(&(g_data.sigvector.sa_mask));
+    g_data.sigvector.sa_flags = 0 ;
+    g_data.sigvector.sa_handler = (void (*)(int)) SIGTERM_hdl;
+    sigaction(SIGTERM, &g_data.sigvector, (struct sigaction *) NULL);
+
+   /*debug:Register segv handler*/ 
+#if 0
+    g_data.sigvector.sa_handler = (void (*)(int))SIGSEGV_hdl;
+    sigaction(SIGSEGV,&g_data.sigvector,(struct sigaction *) NULL);
+#endif
+#ifdef __HTX_LINUX__
+	/* Register SIGUSR2 for handling CPU hotplug */
+    g_data.sigvector.sa_handler = (void (*)(int)) SIGUSR2_hdl;
+    sigaction(SIGUSR2, &g_data.sigvector, (struct sigaction *) NULL);
+	
+#else
+
+	/* Register SIGCPUFIAL handler  */
+    g_data.sigvector.sa_handler = (void (*)(int)) SIGCPUFAIL_handler;
+    (void) sigaction(SIGCPUFAIL, &g_data.sigvector, (struct sigaction *) NULL);
+#endif
+
+}
+
+/*****************************************************************************
+*      displaym(int sev,int debug, const char *format) which print the message on
+*   the screen for stand alone mode run or in the /tmp/htxmsg file otherwise.
+*****************************************************************************/
+int displaym(int sev,int  debug, const char *format,...) {/*RV2: remove locking and g_data.msg_n_err_logging_lock flag*/
+    va_list varlist;
+    char msg[4096];
+    int err; /* error number */
+
+   /* Collect the present error number into err local variable*/
+    err = errno;
+
+   /*
+    * If debug level is 0 (MUST PRINT) we sud always print.
+    * If debug level is > 0  and level of this print is less or equal to
+    * g_data.gstanza.global_debug_level (cmd line global debug level variable) then display this message else
+    * dont display this message. And zero can't be greater than any other debug level
+    * so it always prints below.*/
+    if( debug > g_data.gstanza.global_debug_level) {
+            return(0);
+     }
+
+    va_start(varlist,format);
+    /*if (g_data.msg_n_err_logging_lock)
+        pthread_mutex_lock(&g_data.tmutex);*/
+
+    if (g_data.standalone == 1) {
+        vprintf(format,varlist);
+        fflush(stdout);
+    }
+    else {
+        vsprintf(msg,format,varlist);
+        hxfmsg(&g_data.htx_d,err,sev,msg);
+    }
+
+    /*if (g_data.msg_n_err_logging_lock)
+        pthread_mutex_unlock(&g_data.tmutex);*/
+
+    va_end(varlist);
+    return(0);
+}
+/*****************************************************************************
+*   read_cmd_line function reads the main programs command line
+*   params into the g_data  data structure variable
+*****************************************************************************/
+int read_cmd_line(int argc,char *argv[]) 
+{
+	int i=-1,j=0;
+	char tmp[30],msg[200];
+	char* htxkdblevel;
+	/* Collecting the command line arguments */
+    if (argc > 1){
+        strcpy (DEVICE_NAME, argv[1]);
+	}
+    else {
+		displaym(HTX_HE_INFO,DBG_MUST_PRINT,"device name is missing as first argument, assuming it as /dev/mem\n");
+        strcpy (DEVICE_NAME, "/dev/mem");
+	}
+    if (argc > 2) {
+        strcpy (RUN_MODE, argv[2]);
+        for (i = 0; (i < 4) && (RUN_MODE[i] != '\0'); i++)
+            RUN_MODE[i] = toupper (RUN_MODE[i]);
+
+        if ( strcmp (RUN_MODE, "REG") != 0)
+        {
+            strcpy (RUN_MODE, "OTH");
+            g_data.standalone = 1;
+        }
+    }
+    else  {
+        strcpy (RUN_MODE, "OTH");
+        g_data.standalone = 1;
+    }
+    strcpy (EXER_NAME, argv[0]);
+    if (argc > 3) {
+        strcpy (g_data.rules_file_name, argv[3]);
+    }
+    else { /*Default value */
+        char* rules_tmp_ptr = getenv("HTXREGRULES");
+        if(rules_tmp_ptr == NULL){
+            displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s(): env variable HTXREGRULES is not set,rules_tmp_ptr=%p"
+            ", thus exiting..\n",__LINE__,__FUNCTION__,rules_tmp_ptr);
+            exit(1);
+        }else{
+            strcpy(g_data.rules_file_name,rules_tmp_ptr);
+        }
+        strcat(g_data.rules_file_name,"/hxemem64/default");
+    }
+
+    if (argc > 4) {
+        sscanf(argv[4],"%d",&g_data.gstanza.global_debug_level);
+    }
+    else {
+		g_data.gstanza.global_debug_level=0;
+    }
+
+    /*
+     *  Environment Variable stating whether to enter kdb in case if miscompare.
+     */
+
+    htxkdblevel = getenv("HTXKDBLEVEL");
+    if (htxkdblevel) {
+		g_data.kdb_level = atoi(htxkdblevel);
+    }
+    else {
+        g_data.kdb_level = 0;
+    }
+
+    /* Get the logical processor number in the device name like /dev/mem2 means
+    2nd logical procesor
+    */
+
+    /*RV2: override filters with below cpu number in case of EQUILIZER*/
+    sscanf(DEVICE_NAME,"%[^0-9]s",tmp);
+    strcat(tmp,"%d");
+
+    i = UNSPECIFIED_LCPU;
+    if ((j=sscanf(DEVICE_NAME,tmp,&i)) < 1) {
+        strcpy(msg,"read_cmd_line: No binding specified with the device name.\n");
+        if(g_data.gstanza.global_debug_level == DBG_DEBUG_PRINT) {
+            sprintf(msg,"%sDebug info:%s,i=%d,j=%d\n",msg,tmp,i,j);
+        }
+        i = UNSPECIFIED_LCPU;
+    }
+    else {
+        sprintf(msg,"Binding is specified proc=%i\n",i);
+    }
+
+    if(g_data.standalone == 1) {
+        displaym(HTX_HE_INFO,DBG_IMP_PRINT,"%s",msg);
+    }
+    /*g_data.bind_proc=i;*/
+	g_data.dev_id = i;
+    return(0);
+
+} /* End of read_cmd_line() function */
+
+
+void get_test_type()
+{
+	if(strncmp((char*)(DEVICE_NAME+5),"mem",3) == 0){
+		g_data.test_type = MEM;
+	}	
+	else if ((strncmp ((char*)(DEVICE_NAME+5),"cach",4)) == 0){
+		g_data.test_type = CACHE;
+	}
+	else if (	((strncmp ((char*)(DEVICE_NAME+5),"ab",2)) == 0) || (strncmp ((char*)(DEVICE_NAME+5),"xyz",3)== 0)	){
+		g_data.test_type = FABRICB;
+	}
+	else if ((strncmp ((char*)(DEVICE_NAME+5),"tlb",3)) == 0){
+		g_data.test_type = TLB;
+	}	
+	else {
+		displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:unknown device name %s\n",__LINE__,__FUNCTION__,DEVICE_NAME);
+		exit(1);
+	}
+		
+}
+
+/*************************************************************
+*get_cache_details:returns: void 							 *
+*									 						 *
+*************************************************************/
+void get_cache_details() {
+    htxsyscfg_cache_t cpu_cache_information;
+#ifdef __HTX_LINUX__
+        L2L3cache( &cpu_cache_information);
+#else
+        L2cache( &cpu_cache_information);
+        L3cache( &cpu_cache_information);
+#endif
+
+	g_data.sys_details.cinfo[L2].cache_size = cpu_cache_information.L2_size;
+	g_data.sys_details.cinfo[L2].cache_associativity=cpu_cache_information.L2_asc;;
+	g_data.sys_details.cinfo[L2].cache_line_size = cpu_cache_information.L2_line;
+
+	g_data.sys_details.cinfo[L3].cache_line_size = cpu_cache_information.L3_line;
+	g_data.sys_details.cinfo[L3].cache_size = cpu_cache_information.L3_size;
+	g_data.sys_details.cinfo[L3].cache_associativity=cpu_cache_information.L3_asc;;
+
+	g_data.sys_details.cinfo[L4].cache_line_size = 128;
+	g_data.sys_details.cinfo[L4].cache_size = 16 * MB;
+	g_data.sys_details.cinfo[L4].cache_associativity=16;
+	
+}
+
+
+/*************************************************************
+* get_system_details(): Collects all system hardware details *
+*returns: 0 on success										 *
+*		  -1 on failure										 *
+*************************************************************/	
+
+int get_system_details() {
+	int rc = SUCCESS,i=0,pi=0,count=0,node=0,chip=0,core=0,lcpu=0;
+	htxsyscfg_smt_t     system_smt_information;
+	htxsyscfg_memory_t	sys_mem_info;
+	SYS_STAT			hw_stat;
+	htxsyscfg_env_details_t htx_env;
+	unsigned long		free_mem,tot_mem;
+	struct mem_info* memptr = &g_data.sys_details.memory_details;
+	struct sys_info* sysptr = &g_data.sys_details;
+	struct chip_mem_pool_info* mem_details_per_chip  = &g_data.sys_details.chip_mem_pool_data[0];
+	/* Ask for the library to update its info */
+	rc = repopulate_syscfg(&g_data.htx_d);
+    if( rc != 0) {
+        while(count < 10){
+            sleep(1);
+            rc = repopulate_syscfg(&g_data.htx_d);
+            if(!rc){
+                break;
+            }
+            else {
+                count++;
+            }
+        }
+        if(count == 10 && rc != 0){
+               displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"[%d]%s: Repopulation of syscfg unsuccessful with rc = %d. Exiting\n",__LINE__,__FUNCTION__,rc);
+                return (FAILURE);
+        }
+    }
+	get_env_details(&htx_env);
+	if(strcmp(htx_env.proc_shared_mode,"yes") == 0){
+		sysptr->shared_proc_mode =1;
+	}
+	else {
+		sysptr->shared_proc_mode = 0;
+	}
+	get_smt_details(&system_smt_information);
+    /* Check if smt value returned is valid. If not then exit. */
+    if(system_smt_information.smt_threads >= 1) {
+        sysptr->smt_threads = system_smt_information.smt_threads;
+    }
+    else {
+        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Incorrect value of smt_threads obtained : %d, Exiting\n",__LINE__,__FUNCTION__,system_smt_information.smt_threads);
+        return (FAILURE);
+    }
+
+    /* Get pvr information */
+#if defined(__HTX_LINUX__) && defined(AWAN)
+    sysptr->os_pvr = POWER8_MURANO; /* Hardcode p8 value for AWAN */
+#elif defined(__HTX_LINUX__) && !defined(AWAN)
+    /*system_information.pvr = get_pvr();*/
+    sysptr->os_pvr=get_cpu_version();
+    sysptr->os_pvr = (sysptr->os_pvr)>>16 ;
+	/*####*** add true pvr details*/
+#endif
+	/*REV:below calls need to be replaced with single lib call*/
+	rc=get_memory_size_update();
+    if ( rc ) {
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"get_memory_size__update() failed with rc=%d\n", rc);
+			return (rc);
+    }
+#ifdef __HTX_LINUX__
+    rc=get_page_size_update();
+    if ( rc ) {
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"get_page_size__update() failed with rc=%d\n", rc);
+			return (rc);
+    }
+#endif
+
+    rc = get_page_details();
+    if ( rc ) {
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"get_page_details() failed with rc=%d\n", rc);
+			return (rc);
+    }
+
+    #ifdef __HTX_LINUX__
+    rc = get_memory_pools();
+    if(rc > 0){
+        sysptr->num_chip_mem_pools = sys_mem_info.num_numa_nodes;
+    }
+    #else
+	rc = get_memory_pools_update();
+	if(rc > 0){
+		sysptr->num_chip_mem_pools = sys_mem_info.num_srads;
+	}
+    #endif
+	rc = get_memory_details(&sys_mem_info);
+	if(rc < 0){
+        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:get_memory_details() returned rc = %d\n",__LINE__,__FUNCTION__,rc);
+        return(FAILURE);
+    }
+	memptr->total_mem_avail = sys_mem_info.mem_size.real_mem;/*REV: change in AIX syscfg is required (real_mem * 4KB)*/
+	memptr->total_mem_free  = sys_mem_info.mem_size.free_real_mem;/*REV: change in AIX syscfg is required (real_mem * 4KB)*/
+#ifndef __HTX_LINUX__
+	memptr->pspace_avail	  = sys_mem_info.mem_size.paging_space_total;/*RV2: check, pspase can be removed*/
+	memptr->pspace_free 	  = sys_mem_info.mem_size.paging_space_free;
+#endif
+	
+	for(i=0; i<MAX_PAGE_SIZES; i++) {
+		memptr->pdata[i].supported = FALSE;
+		if(sys_mem_info.page_details[i].supported) {
+			memptr->pdata[i].supported = TRUE;
+			memptr->pdata[i].psize = sys_mem_info.page_details[i].page_size;
+			memptr->pdata[i].avail = (memptr->pdata[i].psize * sys_mem_info.page_details[i].total_pages);
+			memptr->pdata[i].free  = (memptr->pdata[i].psize * sys_mem_info.page_details[i].free_pages);
+		}
+	}			
+
+	/* Fill SRAD/NUMA-NODE related data structres */
+#ifdef __HTX_LINUX__
+	sysptr->num_chip_mem_pools = sys_mem_info.num_numa_nodes;
+#else
+	sysptr->num_chip_mem_pools = sys_mem_info.num_srads;
+#endif
+    sysptr->unbalanced_sys_config = 0;
+	for(i=0;i<sysptr->num_chip_mem_pools;i++){
+		mem_details_per_chip[i].num_cpus						= sys_mem_info.mem_pools[i].num_procs; /* No of cpus in this chip*/
+        mem_details_per_chip[i].chip_id                         = i;
+		memcpy(mem_details_per_chip[i].cpulist,sys_mem_info.mem_pools[i].procs_per_pool,(sizeof(int)*mem_details_per_chip[i].num_cpus));
+		mem_details_per_chip[i].memory_details.total_mem_avail 	= sys_mem_info.mem_pools[i].mem_total;
+		mem_details_per_chip[i].memory_details.total_mem_free	= sys_mem_info.mem_pools[i].mem_free;
+		mem_details_per_chip[i].has_cpu_and_mem 			= sys_mem_info.mem_pools[i].has_cpu_or_mem;               /*flag,to check node has either cpus or memory */ 	
+        if(!mem_details_per_chip[i].has_cpu_and_mem){
+            sysptr->unbalanced_sys_config = 1;
+        }
+		/* Fill page level details for SRAD/NUMA considering 50 % as 4k and 64K in AIX(due to AIX limitation of getting 4k and 64k details per srad**/
+		for(pi=0;pi<MAX_PAGE_SIZES; pi++){
+			if(memptr->pdata[pi].supported == TRUE) {
+#ifndef __HTX_LINUX__ 
+				if((pi < PAGE_INDEX_2M)){/*use explicit page indexes check*/
+					free_mem = (mem_details_per_chip[i].memory_details.total_mem_free * 0.5);
+					free_mem = free_mem/memptr->pdata[pi].psize;
+					free_mem = free_mem * memptr->pdata[pi].psize;
+					
+					tot_mem  = (mem_details_per_chip[i].memory_details.total_mem_avail * 0.5);
+					tot_mem  = tot_mem / memptr->pdata[pi].psize;
+					tot_mem  = tot_mem * memptr->pdata[pi].psize;
+				}else{
+					free_mem = sys_mem_info.mem_pools[i].page_info_per_mempool[pi].free_pages * memptr->pdata[pi].psize;
+					tot_mem  = sys_mem_info.mem_pools[i].page_info_per_mempool[pi].total_pages * memptr->pdata[pi].psize;
+				}
+#else
+				free_mem = sys_mem_info.mem_pools[i].page_info_per_mempool[pi].free_pages * memptr->pdata[pi].psize;
+				tot_mem  = sys_mem_info.mem_pools[i].page_info_per_mempool[pi].total_pages * memptr->pdata[pi].psize;
+#endif
+				mem_details_per_chip[i].memory_details.pdata[pi].supported = TRUE;
+				mem_details_per_chip[i].memory_details.pdata[pi].free = free_mem; 
+				mem_details_per_chip[i].memory_details.pdata[pi].avail = tot_mem;
+				mem_details_per_chip[i].memory_details.pdata[pi].psize= memptr->pdata[pi].psize;
+                /*initialize memory filter specific data structures*/
+                mem_details_per_chip[i].memory_details.pdata[pi].page_wise_usage_mpercent = 0;
+                mem_details_per_chip[i].memory_details.pdata[pi].page_wise_usage_mem      = 0;
+                mem_details_per_chip[i].memory_details.pdata[pi].page_wise_usage_npages   = 0;
+                mem_details_per_chip[i].memory_details.pdata[pi].in_use_num_of_segments   = 0; 
+   			}
+		}
+	}
+	/*get hardware htx_d info */
+	rc = get_hardware_stat( &hw_stat );
+	if (rc == -1) {
+		displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:get_hardware_stat() returned rc = %d\n",__LINE__,__FUNCTION__,rc);
+		return (FAILURE);
+	}
+	sysptr->nodes = hw_stat.nodes;
+	sysptr->chips = hw_stat.chips;
+	sysptr->cores = hw_stat.cores;
+	sysptr->tot_cpus = hw_stat.cpus;
+    rc = pthread_rwlock_rdlock(&(global_ptr->syscfg.rw));
+    if (rc != 0 ) {
+       displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:lock inside nest_framework.c failed with rc = %d and errno=%d\n", __LINE__,__FUNCTION__,rc,errno);
+        
+    }
+    int srad_counter=0;
+    for( node = 0; node < MAX_NODES && node < hw_stat.nodes ; node++ ) {
+		if(global_ptr->syscfg.node[node].num_chips > 0) {
+	    	for(chip = 0; chip < MAX_CHIPS && chip < global_ptr->syscfg.node[node].num_chips; chip++ ) {	        
+	        	if(global_ptr->syscfg.node[node].chip[chip].num_cores > 0) { 
+		   			for(core = 0; core < MAX_CORES && core < global_ptr->syscfg.node[node].chip[chip].num_cores; core++ ) {
+						if(global_ptr->syscfg.node[node].chip[chip].core[core].num_procs > 0) {
+			    			for(lcpu=0;lcpu < MAX_CPUS &&  lcpu < global_ptr->syscfg.node[node].chip[chip].core[core].num_procs;lcpu++){
+				
+								sysptr->node[node].chip[chip].core[core].lprocs[lcpu] = global_ptr->syscfg.node[node].chip[chip].core[core].lprocs[lcpu];
+		   	   					sysptr->node[node].chip[chip].core[core].num_procs++;
+								debug(HTX_HE_INFO,DBG_DEBUG_PRINT,"sysptr->node[%d].chip[%d].core[%d].lprocs[%d]=%d\n",node,chip,
+								core,lcpu,sysptr->node[node].chip[chip].core[core].lprocs[lcpu]);
+
+     			    		}
+
+		   				}
+		     		    sysptr->node[node].chip[chip].num_cores++;
+		   			}	
+                    memcpy(&sysptr->node[node].chip[chip].mem_details,&g_data.sys_details.chip_mem_pool_data[srad_counter].memory_details,sizeof(struct mem_info));         	
+				}
+                srad_counter++;
+	    		sysptr->node[node].num_chips++;
+	    	}
+		}
+    }
+    rc = pthread_rwlock_unlock(&(global_ptr->syscfg.rw));
+    if (rc !=0  ) {
+        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:unlock inside framework.c failed with rc = %d and errno=%d\n",__LINE__,__FUNCTION__,rc,errno);
+		return(FAILURE);
+    }
+
+	get_cache_details();
+	return (SUCCESS);
+
+}
+/*RV3: look in old code for modification of shmax,shmni*/
+int apply_process_settings() {
+	int rc;
+	struct sys_info* sysptr = &g_data.sys_details;
+	FILE *fp=NULL;
+#ifndef __HTX_LINUX__
+    int early_lru = 1; /* 1 extends local affinity via paging space.*/
+    int num_policies = VM_NUM_POLICIES;
+    int policies[VM_NUM_POLICIES] = {/* -1 = don't change policy */
+    -1, /* VM_POLICY_TEXT */
+    -1, /* VM_POLICY_STACK */
+    -1, /* VM_POLICY_DATA */
+    P_FIRST_TOUCH, /* VM_POLICY_SHM_NAMED */
+    P_FIRST_TOUCH, /* VM_POLICY_SHM_ANON */
+    -1, /* VM_POLICY_MAPPED_FILE */
+    -1, /* VM_POLICY_UNMAPPED_FILE */
+    };
+
+
+	/* To get local memory set flag early_lru=1 to select P_FIRST_TOUCH policy(similiar to setting MEMORY_AFFINITY environment variable to MCM)*/
+	rc = vm_mem_policy(VM_SET_POLICY,&early_lru, &policies ,num_policies);
+	if (rc != 0){
+		displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"vm_mem_policy() call failed with return value = %d\n",rc);
+	}
+#endif
+
+#ifdef __HTX_LINUX__
+	/* collect shm related values from file system*/
+	fp = popen("cat /proc/sys/kernel/shmmax","r");
+	if (fp == NULL ) {
+		displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s:popen failed for /proc/sys/kernel/shmmax,errno=%d\n",
+			__LINE__,__FUNCTION__,errno);
+		return (FAILURE);
+	}
+	rc = fscanf(fp,"%d",&sysptr->shmmax);
+	if (rc == 0 || rc == EOF) {
+		displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s:fscanf failed for shmmax with rc = %d,errno=%d\n",
+			__LINE__,__FUNCTION__,rc,errno);
+		pclose(fp);
+		return (FAILURE);
+	}
+	pclose(fp);
+
+
+    fp = popen("cat /proc/sys/kernel/shmall","r");
+    if (fp == NULL) {
+        displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s:popen failed for /proc/sys/kernel/shmall,errno=%d\n",
+			 __LINE__,__FUNCTION__,errno);
+		return (FAILURE);
+    }
+    rc  = fscanf(fp,"%d",&sysptr->shmall);
+    if (rc == 0 || rc == EOF) {
+        displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s:fscanf failed for shmall with rc = %d,errno=%d\n",
+			 __LINE__,__FUNCTION__,rc,errno);
+		pclose(fp);
+		return (FAILURE);
+    }
+    pclose(fp);
+
+    fp = popen("cat /proc/sys/kernel/shmmni","r");
+    if (fp == NULL)  {
+        displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s:popen failed for /proc/sys/kernel/shmmni,errno=%d\n",
+			__LINE__,__FUNCTION__,errno);
+		return (FAILURE);
+    }
+    rc  = fscanf(fp,"%d",&sysptr->shmmni);
+    if (rc == 0 || rc == EOF) {
+        displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s:fscanf failed for shmmni with rc = %d,errno=%d\n",
+			__LINE__,__FUNCTION__,rc,errno);
+		pclose(fp);
+		return (FAILURE);
+    }
+    pclose(fp);
+#endif
+	return (SUCCESS);
+
+}
+/*****************************************************************************
+*  MAIN: begin program main procedure                                        *
+*****************************************************************************/
+int main(int argc, char *argv[])
+{
+	int ret_code=SUCCESS;
+    char command[256];
+	/*Register signal  handlers*/
+	reg_sig_handlers();
+
+	/* Intialize mutex variable */
+    if ( pthread_mutex_init(&g_data.tmutex,NULL) != 0) { 
+         displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"[%d]%s:pthread init error (%d): %s\n",__LINE__,__FUNCTION__,errno,strerror(errno));
+    }
+    g_data.msg_n_err_logging_lock= 1; /* flag set that means mutex variable exists*/
+
+
+	/* Read the command line parameters */
+	ret_code = read_cmd_line(argc,argv);
+	if(ret_code != SUCCESS){
+		 displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:read_cmd_line() failed with ret_code = %d\n",__LINE__,__FUNCTION__,ret_code);
+	}
+	
+	/* Store the pid of the process */
+	g_data.pid=getpid();
+
+#ifdef __HTX_LINUX__
+    /* Set coredump config file to 0x31, so that if any coredump generated should not contain share memory mapings*/
+    sprintf(command,"echo 49 > /proc/%d/coredump_filter",g_data.pid);
+    ret_code = system(command);
+    if(ret_code == -1){
+        displaym(HTX_HE_INFO,DBG_MUST_PRINT,"[%d]%s: comand: '%s' failed, If any core dump, it will also include shared mem mapings!!\n",
+            __LINE__,__FUNCTION__,command);
+    }
+#endif
+	get_test_type(); /*retreives running exer type*/
+
+	/* Notify Supervisor of exerciser start and 
+	 * set htx_data flag(hotplug_cpu) to make supervisor aware that we want to recieve SIGUSR2 in case of Linux hotplug add/remove */
+#ifdef __HTX_LINUX__
+    STATS_VAR_INIT(hotplug_cpu, 1)
+#endif
+    STATS_HTX_UPDATE(START)
+    STATS_HTX_UPDATE(UPDATE)
+	displaym(HTX_HE_INFO,DBG_MUST_PRINT,"%s %s %s %s %d\n",EXER_NAME,DEVICE_NAME,RUN_MODE,\
+		g_data.rules_file_name,g_data.gstanza.global_debug_level);
+
+    if((!(strlen(g_data.htx_d.htx_log_dir))) || (!(strlen(g_data.htx_d.htx_exer_log_dir)))){
+     
+        displaym(HTX_HE_INFO,DBG_MUST_PRINT,"htx lib log direcories found to be htx_log_dir= %s and htx_exer_log_dir= %s, thus updating them to '/tmp/'\n",
+            g_data.htx_d.htx_log_dir,g_data.htx_d.htx_exer_log_dir);
+        strcpy(g_data.htx_d.htx_log_dir,"/tmp/");
+        strcpy(g_data.htx_d.htx_exer_log_dir,"/tmp/");
+    }
+	FILE* fp;
+	sprintf(command,"grep -i global_startup_delay %s | awk '{print $3}'",g_data.rules_file_name);
+    fp = popen(command,"r");
+    if (fp == NULL) {
+        displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,
+                        "popen failed for command:%d errno(%d)\n",command,errno);
+        return(FAILURE);
+    }
+    ret_code  = fscanf(fp,"%d",&g_data.gstanza.global_startup_delay);
+    if (ret_code == 0 || ret_code == EOF) {
+		displaym(HTX_HE_HARD_ERROR,DBG_DEBUG_PRINT,"setting global_startup_delay to %d sec",DEFAULT_DELAY);
+		g_data.gstanza.global_startup_delay = DEFAULT_DELAY;
+    }
+    pclose(fp);
+    if((g_data.standalone != 1) && (g_data.test_type == MEM) && (g_data.gstanza.global_startup_delay)){
+        displaym(HTX_HE_INFO, DBG_MUST_PRINT, "Waiting %d second(s), "
+                 "while other exercisers allocate their memory.\n",
+                g_data.gstanza.global_startup_delay);
+        sleep(g_data.gstanza.global_startup_delay);
+		sleep(g_data.gstanza.global_startup_delay);
+    }	
+	/* Collect system details */
+	ret_code = get_system_details();
+	if(ret_code != SUCCESS){
+		displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:get_system_details() failed with ret_code = %d\n",__LINE__,__FUNCTION__,ret_code);
+		exit(1);
+	}
+    print_partition_config();
+
+    if (g_data.exit_flag == 1) {
+        return(-1);
+    } 
+
+    g_data.rf_last_mod_time = 0;
+	if ((read_rules()) < 0 ) {
+		exit(1);/*RV3: check for error possibility*/
+	}
+
+    if (g_data.exit_flag == 1) {
+        return(-1);
+    } 
+	
+	/* apply process level settings/policies */
+	ret_code = apply_process_settings();
+	if(ret_code != SUCCESS){
+		displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:(apply_process_settings) failed with ret_code = %d\n",__LINE__,__FUNCTION__,ret_code);
+		exit(1);
+	}
+
+	/* Call test specific functions */
+	switch (g_data.test_type) {
+		case MEM:
+			ret_code = mem_exer_opearation();
+			if(ret_code != SUCCESS){
+					exit(1);
+			}
+			break;
+		
+		case TLB:
+			break;
+	
+		case CACHE:
+			break;
+
+		case FABRICB:
+			break;
+
+		default:
+			displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:wrong test type,it must be one of - /mem/cache/tlbie/fabricb \n",
+					__LINE__,__FUNCTION__);			
+			return(FAILURE);
+	}
+
+	return(SUCCESS);
+}/*end of main*/
+
+
+void print_partition_config(){
+    int i=0,pi=0;
+    char msg[4096],msg_temp[2048];
+    struct mem_info* memptr = &g_data.sys_details.memory_details;
+    struct sys_info* sysptr = &g_data.sys_details;
+    struct chip_mem_pool_info* mem_details_per_chip  = &g_data.sys_details.chip_mem_pool_data[0];
+
+    sprintf(msg,"SYSTEM DETAILS:\t\tNodes=%d\tChips=%d\tCores=%d\tLogical cpus=%d\n" 
+        "\n\tTotal memory:%llu MB\n\tFree memory:%llu MB\n\tTotal paging space:%lu\n\tFreepaging space:%lu\n",
+        sysptr->nodes,sysptr->chips,sysptr->cores,sysptr->tot_cpus,
+        (memptr->total_mem_avail/MB),(memptr->total_mem_free/MB),memptr->pspace_avail,memptr->pspace_free);
+
+    for(i=0; i<MAX_PAGE_SIZES; i++) {
+    if(memptr->pdata[i].supported) {
+            sprintf(msg_temp,"\tpage size:%lu(%s)\t total pages=%lu\tfree pages=%lu\n",memptr->pdata[i].psize,page_size_name[i],
+                (memptr->pdata[i].avail/memptr->pdata[i].psize),
+                (memptr->pdata[i].free/memptr->pdata[i].psize)); 
+            strcat(msg,msg_temp);
+        }
+    }
+    displaym(HTX_HE_INFO,DBG_MUST_PRINT,"%s",msg);
+    sprintf(msg,"Chip level mem details:\n\nCHIP\tCPU\tMEM\n-----------------------\n");
+    for(i=0;i<sysptr->num_chip_mem_pools;i++){
+        if(mem_details_per_chip[i].num_cpus > 0){
+            sprintf(msg_temp," %d\t Y\t",i);
+        }else{
+            sprintf(msg_temp," %d\t N\t",i);
+        }
+        strcat(msg,msg_temp);
+        if(mem_details_per_chip[i].memory_details.total_mem_avail > 0){
+            sprintf(msg_temp," Y\t\n");
+        }else {
+            sprintf(msg_temp," N\t\n");
+        }  
+        strcat(msg,msg_temp);
+    } 
+    for(i=0;i<sysptr->num_chip_mem_pools;i++){
+        if(mem_details_per_chip[i].has_cpu_and_mem){
+            sprintf(msg_temp,"\nchip no:%d\n\tcpus:%d",i,mem_details_per_chip[i].num_cpus);
+            strcat(msg,msg_temp);
+            /*for(k=0;k<mem_details_per_chip[i].num_cpus;k++){
+                sprintf(msg_temp,":%d",mem_details_per_chip[i].cpulist[k]);
+                strcat(msg,msg_temp);
+            }*/
+            sprintf(msg_temp,"\n\tTotal mem :%llu MB\n\tFree mem :%llu MB\n",
+                (mem_details_per_chip[i].memory_details.total_mem_avail/MB),(mem_details_per_chip[i].memory_details.total_mem_free/MB));
+            strcat(msg,msg_temp);
+            for(pi=0;pi<MAX_PAGE_SIZES; pi++){
+                if(mem_details_per_chip[i].memory_details.pdata[pi].supported){
+                    sprintf(msg_temp,"\tpage size:%lu(%s)\t total pages =%lu\tfree pages =%lu\n",mem_details_per_chip[i].memory_details.pdata[pi].psize, page_size_name[pi],
+                        (mem_details_per_chip[i].memory_details.pdata[pi].avail/mem_details_per_chip[i].memory_details.pdata[pi].psize),
+                        (mem_details_per_chip[i].memory_details.pdata[pi].free/mem_details_per_chip[i].memory_details.pdata[pi].psize));
+                    strcat(msg,msg_temp);
+                }
+            }
+        }
+    }
+    displaym(HTX_HE_INFO,DBG_MUST_PRINT,"%s\n",msg);
+}
+	
+int fill_exer_huge_page_requirement(){
+	int rc = SUCCESS;
+	unsigned long avail_16m,avail_16g,free_16m,free_16g;
+	struct mem_info* memptr = &g_data.sys_details.memory_details;
+	FILE *fp;
+    char log_dir[256];
+	int huge_page_size,huge_page_index;
+	if(memptr->pdata[PAGE_INDEX_16M].supported){
+		huge_page_index = PAGE_INDEX_16M;
+		huge_page_size = (16 * MB);
+	}else if(memptr->pdata[PAGE_INDEX_2M].supported){
+		huge_page_index = PAGE_INDEX_2M;
+		huge_page_size = (2 * MB);
+	}
+    strcpy(log_dir,g_data.htx_d.htx_log_dir);
+    strcat(log_dir,"/freepages");
+	if ((fp=fopen(log_dir,"r"))==NULL) {
+         displaym(HTX_HE_SOFT_ERROR,DBG_MUST_PRINT,"[%d]%s:fopen of memory free pages (%s) failed with errno:%d(%s)\n",
+            __LINE__,__FUNCTION__,log_dir,errno,strerror(errno));
+	}
+	else {
+		rc = fscanf(fp,"avail_16M=%lu,avail_16G=%lu,free_16M=%lu,free_16G=%lu",&avail_16m,\
+                    &avail_16g,&free_16m,&free_16g);
+		if(rc == 0 || rc == EOF) {
+			displaym(HTX_HE_INFO,DBG_MUST_PRINT, "[%d]%s:Error while reading file (%s),errno:%d(%s)" 
+				"making huge  page support as false\n",__LINE__,__FUNCTION__,log_dir,errno,strerror(errno));
+			memptr->pdata[PAGE_INDEX_2M].supported = FALSE;
+			memptr->pdata[PAGE_INDEX_16M].supported = FALSE;
+			memptr->pdata[PAGE_INDEX_16G].supported = FALSE;
+		}else{
+			
+			switch(g_data.test_type) {
+			
+				case MEM:
+                        if(g_data.gstanza.global_alloc_huge_page == 0){
+                            memptr->pdata[PAGE_INDEX_16M].supported = FALSE;
+                            memptr->pdata[PAGE_INDEX_2M].supported = FALSE;
+                            memptr->pdata[PAGE_INDEX_16G].supported = FALSE;
+                        }
+						if(memptr->pdata[PAGE_INDEX_16M].supported || memptr->pdata[PAGE_INDEX_2M].supported){
+							 memptr->pdata[huge_page_index].avail = (avail_16m * huge_page_size);
+							 memptr->pdata[huge_page_index].free	= (free_16m * huge_page_size);
+						}
+						 memptr->pdata[PAGE_INDEX_16G].avail = (avail_16g * 16 * GB);
+						 memptr->pdata[PAGE_INDEX_16G].free	= (free_16g * 16 * GB);
+						 break;
+
+				/* Add cache,fabric,tlbie,L4 */
+				default:
+					displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]wrong test type arg is passed to fun %s for filling huge page deatils from %s\n",
+							__LINE__,__FUNCTION__,log_dir);			
+					return(FAILURE);
+			}		
+		fclose(fp);
+		displaym(HTX_HE_INFO,DBG_MUST_PRINT,"huge page details from %s avail_16M/2M=%lu,avail_16G=%lu,free_16M/2M=%lu,free_16G=%lu\n",log_dir,avail_16m,avail_16g,free_16m,free_16g);
+		}
+		
+	}
+	return (SUCCESS);
+}
+#ifdef __HTX_LINUX__
+int modify_shared_mem_limits_linux(unsigned long total_segments){
+    int rc;
+    FILE *fp;
+    char oth_exer_segments[20],cmd[100];
+    unsigned long new_shmmni;
+    /* Set shmmax value to 256MB only if the value on current system is less than that */
+    /* taken care in mem.setup by setting up shmmax to 1GB*/
+    if (g_data.sys_details.shmmax < 268435456) {
+        displaym(HTX_HE_INFO,DBG_MUST_PRINT,"Changing the /proc/sys/kernel/shmmax variable to 256MB\n");
+        rc = system ("echo 268435456 > /proc/sys/kernel/shmmax");
+        if(rc < 0){
+            displaym(HTX_HE_INFO,DBG_MUST_PRINT,"unable to change the /proc/sys/kernel/shmmax variable to 256MB\n");
+        }
+    }
+    
+    /* /proc/sys/kernel/shmall value have been taken care in htx.setup by setting up it to 90% of total memory*/
+    
+    fp = popen("ipcs -m | grep root | wc -l", "r");
+    if (fp == NULL) {
+        displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,
+                        "popen failed for ipcs command: errno(%d)\n", errno);
+        return(-1);
+    }
+    rc  = fscanf(fp,"%s",oth_exer_segments);
+    if (rc == 0 || rc == EOF) {
+        displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s: "
+                        "Could not read oth_exer_segments from pipe\n",__LINE__,__FUNCTION__);
+        return(FAILURE);
+    }
+    pclose(fp);
+
+    if(g_data.sys_details.shmmni < strtoul(oth_exer_segments, NULL, 10) + total_segments) {
+        new_shmmni = g_data.sys_details.shmmni + strtoul(oth_exer_segments, NULL, 10) + total_segments;
+        displaym(HTX_HE_INFO,DBG_MUST_PRINT,"Changing the /proc/sys/kernel/shmmni variable to %lu\n",new_shmmni);
+        sprintf(cmd,"echo %lu > /proc/sys/kernel/shmmni", new_shmmni);
+        rc = system (cmd);
+        if(rc < 0){
+            displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s:unable to change the /proc/sys/kernel/shmmni variable to %lu\n",
+                __LINE__,__FUNCTION__,new_shmmni);
+            return (FAILURE);
+        }
+    }
+    return SUCCESS;
+}
+#endif
+

--- a/bin/hxemem64/nest_framework.h
+++ b/bin/hxemem64/nest_framework.h
@@ -1,0 +1,573 @@
+/* IBM_PROLOG_BEGIN_TAG */
+/*
+ * Copyright 2003,2016 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/signal.h>
+#include <stdarg.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <time.h>
+#include <sys/ipc.h>
+#include <pthread.h>
+#include <memory.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>  /* memcpy .. etc */
+#include <sys/shm.h>
+#include <limits.h>
+#include "hxihtx64.h"
+#include "htxsyscfg64.h"
+#ifdef       _DR_HTX_
+#include <sys/dr.h>
+#endif
+
+#define SUCCESS				0
+#define FAILURE				-1
+
+#define DEVICE_NAME  g_data.htx_d.sdev_id
+#define RUN_MODE    g_data.htx_d.run_type
+#define EXER_NAME   g_data.htx_d.HE_name
+
+#define RUN_TYPE_LENGTH		4
+#define MAX_STRING_LENTGH	32
+#define RULE_FILE_NAME_LENGTH	80
+#define BIND_TO_PROCESS     0
+#define BIND_TO_THREAD      1
+#define UNBIND_ENTITY       -1
+#define UNSPECIFIED_LCPU    -1
+#define MAX_STANZAS         41  /* Only 40 stanzas can be used */
+#define MAX_NX_TASK         20
+#define SW_PAT_OFF          0
+#define SW_PAT_ON           1
+#define SW_PAT_ALL          2
+#define MIN_PATTERN_SIZE    8
+#define MAX_PATTERN_SIZE    4096
+#define MAX_RULE_LINE_SIZE  700     /* Inline with pattern text widths */
+
+#define LS_BYTE             1       /* Load-Store Bytes */
+#define LS_WORD             4       /* Load-Store Words */
+#define LS_DWORD            8       /* Load-Store Double Words */
+
+#define MIN_MEM_PERCENT     1
+#define MIN_CPU_PERCENT		10
+#define DEFAULT_MEM_PERCENT 100
+#define DEFAULT_CPU_PERCENT 100
+#define DEFAULT_MEM_ALOC_PERCENT 70
+#define MAX_MEM_PERCENT     99          /* Not implemented */
+#define MAX_CPU_PERCENT   	100
+#define DEFAULT_DELAY       90
+#define ADDR_PAT_SIGNATURE  0x414444525F504154  /* Hex equiv of "ADDR_PAT" */
+#define RAND_PAT_SIGNATURE  0x52414E445F504154  /* Hex equiv of "RAND_PAT" */
+
+#define MAX_CPUS_PER_SRAD   MAX_CPUS_PER_CHIP
+#define MAX_L4_MASKS		2
+#define MAX_CACHES			4
+#define CACHE_LINE_SIZE		128
+#define KB                  1024
+#define MB                  ((unsigned long long)(1024*KB))
+#define GB                  ((unsigned long long)(1024*MB))
+
+/* Page indexes  0 - Index for page size 4k, 1 -Index for page size 64k,
+ * 2 - Index for page size 2M,3 - Index for page size 16M,4 - Index for page size 16G
+ */
+#if 0
+#define MAX_PAGE_SIZES	 5			/*RV:move to syscfg lib*/
+#define PAGE_INDEX_4K    0			/* duplicate if syscfg library included*/
+#define PAGE_INDEX_64K   1
+#define PAGE_INDEX_2M	 2
+#define PAGE_INDEX_16M   3
+#define PAGE_INDEX_16G   4
+#endif
+
+/*move below macros to mem specific file later*/
+#define MAX_STRIDE_SZ  4*KB
+
+#define MIN_SEG_SIZE		8					/* 1 byte size*/
+#define DEF_SEG_SZ_4K       256*MB
+#define DEF_SEG_SZ_64K      DEF_SEG_SZ_4K
+#define DEF_SEG_SZ_2M		DEF_SEG_SZ_4K
+#define DEF_SEG_SZ_16M      DEF_SEG_SZ_4K
+#define DEF_SEG_SZ_16G      16*GB
+
+#define DBG_MUST_PRINT 0
+#define DBG_IMP_PRINT 1
+#define DBG_INFO_PRINT 2
+#define DBG_DEBUG_PRINT 3
+
+#define MAX_FILTERS             20
+#define MAX_POSSIBLE_ENTRIES    200
+
+#define STATS_VAR_INC(var, val) \
+    pthread_mutex_lock(&g_data.tmutex);\
+    g_data.htx_d.var += val; \
+    pthread_mutex_unlock(&g_data.tmutex);
+
+#define STATS_VAR_INIT(var, val) \
+    pthread_mutex_lock(&g_data.tmutex); \
+    g_data.htx_d.var = val; \
+    pthread_mutex_unlock(&g_data.tmutex);
+
+#ifndef __HTX_LINUX__
+    #define STATS_HTX_UPDATE(stage)\
+        pthread_mutex_lock(&g_data.tmutex); \
+        hxfupdate(stage,&g_data.htx_d); \
+        pthread_mutex_unlock(&g_data.tmutex);
+#else
+    #define STATS_HTX_UPDATE(stage) \
+    hxfupdate(stage,&g_data.htx_d);
+#endif
+
+#ifdef DEBUG_ON
+	#define debug(...)     displaym(__VA_ARGS__)
+#else
+	#define debug(...)
+#endif
+enum test_type { MEM=0, CACHE, FABRICB, TLB };
+enum oper_type { OPER_MEM=0, OPER_DMA, OPER_RIM, OPER_TLB, OPER_MPSS, OPER_STRIDE, OPER_L4_ROLL, OPER_MBA, OPER_CORSA };
+enum run_mode_type { RUN_MODE_NORMAL=0, RUN_MODE_CONCURRENT, RUN_MODE_COHERENT };
+enum caches	{ L1=0,L2,L3,L4 };
+enum affinity { LOCAL=1,REMOTE_CHIP,FLOATING,INTRA_NODE,INTER_NODE,ABOSOLUTE };
+
+#define WRC                     3
+#define MAX_PATTERN_TYPES       4
+#define MAX_OPER_TYPES          4
+#define MAX_MEM_ACCESS_TYPES    3 
+enum pattern_size_type { PATTERN_SIZE_NORMAL=0, PATTERN_SIZE_BIG, PATTERN_ADDRESS, PATTERN_RANDOM };
+enum basic_oper {WRITE=0,READ,COMPARE,RIM};
+enum width_oper {DWORD=0,WORD,BYTE};
+
+typedef int (*op_fptr)(int,void*,void*,int,void*,void*,void*,void*);
+
+struct page_wise_seg_info {
+	unsigned long seg_num;
+	unsigned long shm_size; /* value get modified for segs if user gives mem filetr with size less 256MB(for4k and 64k pages)*/
+    unsigned long original_shm_size;/*update "shm_size" variable with "original_shm_size" after every stanza*/
+	unsigned long shmid;
+	char *shm_mem_ptr;
+	signed int  owning_thread	 : 12;
+	unsigned int page_size_index : 5;/*0-4k,1-64k,2-2M,3-16M,4-16G*/
+	unsigned int in_use		     : 1;
+	signed int  cpu_chip_num	 : 8;
+	signed int  mem_chip_num	 : 8;
+};	
+	
+/*
+ * page wise data structure having page wise free,
+ * total and other page wise data.
+ */
+struct page_wise_data {
+    int supported;
+    unsigned long free;
+    unsigned long avail;
+    unsigned long psize;
+	unsigned int num_of_segments;
+	struct page_wise_seg_info *page_wise_seg_data;	
+	/*memory filter specific data*/
+	int  page_wise_usage_mpercent;
+	unsigned long page_wise_usage_mem;
+	int  page_wise_usage_npages; 
+    unsigned int in_use_num_of_segments;
+};
+
+/*RV1: re check first 4 variable does make any sense at chip level mem details
+create a new system level meminfo and embed chip level meminfo ( another structure in to it)*/
+struct mem_info {
+    unsigned long pspace_avail;/* total paging space available */ 
+    unsigned long pspace_free; /* total paging space free */
+    unsigned long total_mem_avail; /* Total memory (real) available */
+    unsigned long total_mem_free;  /* Total memory (real) free */
+    struct page_wise_data pdata[MAX_PAGE_SIZES];
+};
+
+/*This structure holds the srad related data */
+struct chip_mem_pool_info{
+	int has_cpu_and_mem;  /*flag,to check node has both cpus and  memory it,  0-only cpu or mem or no cpu and no mem.  1-has both cpu and mem*/
+	int chip_id;
+	int cpulist[MAX_CPUS_PER_SRAD];
+	int num_cpus;  /* No of cpus in this srad */
+	struct mem_info memory_details;
+	/*cpu filter specific data*/
+	int in_use_num_cpus;
+	int in_use_cpulist[MAX_CPUS_PER_SRAD];/* active cpus list for a chip after applying cpu filter*/
+	int is_chip_mem_in_use; /* based on memory filter update this var, FALSE  - mem not in use, TRUE  - in use*/
+};
+
+struct core_info{
+    unsigned int core_num;
+    unsigned int num_procs;
+    unsigned int lprocs[MAX_CPUS_PER_CORE];
+};
+
+struct chip_info{
+    unsigned int chip_num;
+    unsigned int num_cores;
+	unsigned int lprocs[MAX_CPUS_PER_CHIP];
+    struct core_info core[MAX_CORES_PER_CHIP];
+    struct mem_info mem_details;
+};
+
+struct node_info{
+    unsigned int node_num;
+    unsigned int num_chips;
+	unsigned int lprocs[MAX_CPUS_PER_NODE];
+    struct chip_info chip[MAX_CHIPS_PER_NODE];
+};
+
+struct cache_details {
+	unsigned int cache_size;
+	unsigned int cache_associativity;
+	unsigned int cache_line_size;
+};
+
+struct sys_info {
+	unsigned int os_pvr;
+	unsigned int true_pvr;
+	int smt_threads;
+	int tot_cpus;
+    unsigned int nodes;
+    unsigned int chips;
+    unsigned int cores;
+	int shared_proc_mode;
+    int unbalanced_sys_config;/* will be set, when any chip in lapr has only mem or only cpu it,not both*/
+	struct node_info node[MAX_NODES];
+	struct cache_details cinfo[MAX_CACHES];/*RV1: cinfo ===> cache_info*/
+	struct mem_info memory_details; /*RV1: dont need to keep all mem deatils at system level*/
+	int num_chip_mem_pools;
+	struct chip_mem_pool_info chip_mem_pool_data[MAX_CHIPS];
+	int shmmax;
+	int shmall;
+	int shmmni;
+};
+
+/*rule information data structure*/
+struct cpu_filter_info{
+    struct node_info node[MAX_NODES];
+    int num_nodes;
+};
+struct mem_filter_info{
+    struct node_info node[MAX_NODES];
+    int num_nodes;
+};
+struct filter_info{
+    struct cpu_filter_info cf;
+    struct mem_filter_info mf;
+};
+
+struct global_rule{
+    unsigned int global_alloc_mem_percent;
+	unsigned int global_mem_4k_use_percent;
+	unsigned int global_mem_64k_use_percent;
+    int          global_alloc_huge_page;
+	long 		 global_alloc_mem_size; 
+    long         global_alloc_segment_size;
+    int          global_debug_level;
+    int          global_disable_cpu_bind;
+    int			 global_startup_delay;    /* Seconds to sleep before starting the test */
+	int 		 global_disable_filters;
+	int 		 global_num_threads; /* used only in case of disable_filters = yes*/
+};
+/*RV1: Keep mem specific parameters only, remove others*/
+struct rule_info {
+    char  rule_id[16];      /* Rule Id                                        */
+    char  pattern_id[9];   /* /htx/pattern_lib/xxxxxxxx                      */
+    int   num_oper;        /* number of operations to be performed           */
+                            /* 1 = default for invalid or no value            */
+    int   num_writes;       /* 1 is default value */
+    int   num_reads;        /* 1 is default value */
+    int   num_compares;     /* 1 is default value */
+    int   operation;        /* assigned to #defined values OPER_MEM.. etc    */
+    int   run_mode;         /* assigned to #defined values MODE_NORMAL.. etc */
+    int   misc_crash_flag;  /* 1 = crash_on_misc = ON and 0 = OFF */
+    int   attn_flag;        /* 1 = turn on attention , 0 = OFF */
+    int   compare_flag;     /* 1 = compare ON, 0 = compare OFF */
+    int   disable_cpu_bind;     /* 1 = BINDING OFF(YES in rule file), 0  = BINDING ON(NO in rule file) */
+    int   random_bind;      /* yes = random cpu bind on, no  = random cpu bind off */
+    int   switch_pat;       /* 2 = Run (ALL) patterns for each segment,
+                               1 = Switch pattern per segment is (ON)
+                                   use a different pattern for each new segment,
+                               0 = (OFF) Use the same pattern for all segments.
+                               Note: For this variable to be effective multiple
+                               patterns have to be specified */
+    char  oper[8];         /* DMA or MEM or RIM                              */
+    char  messages[4];     /* YES - put out info messages                    */
+                            /* NO - do not put out info messages              */
+    unsigned long seed;
+    int    num_threads; /* Number of threads */
+    int    percent_hw_threads; /* percentage of available H/W threads*/
+    char  compare[4];      /* YES - compare                                  */
+                            /* NO -  no compare                               */
+    int   width;           /* 1, 4, or 8 bytes at a time                     */
+	int   mem_percent;
+	int	  cpu_percent;
+    int   debug_level; /* Only 0 1 2 3 value .See the #define DBG_MUST_PRINT for more*/
+    char  crash_on_mis[4];    /* Flag to enter the kdb in case of miscompare,   */
+                    /* yes/YES/no/NO */
+    char  turn_attn_on[4];    /* Flag to enter the attn in case of miscompare,  */
+                        /* yes/YES/no/NO */
+    char pattern_nm[52];
+    int   num_patterns;
+    unsigned int pattern_size[MAX_STANZA_PATTERNS];
+    int   pattern_type[MAX_STANZA_PATTERNS]; /* pattern type (enum pattern_type) */
+    char  pattern_name[MAX_STANZA_PATTERNS][72];
+    char  *pattern[MAX_STANZA_PATTERNS];
+    int affinity;
+    char nx_mem_operations[72];
+    int     number_of_nx_task;
+    /*struct nx_task_table nx_task[MAX_NX_TASK];  NX specific*/
+    char nx_reminder_threads_flag[10];
+    int nx_rem_th_flag;
+    char nx_performance_data[10];
+    int nx_perf_flag;
+    char nx_async[10];
+    int nx_async_flag;
+    int stride_sz;
+    char mcs[8];
+    int mem_l4_roll;
+    long mcs_mask;
+    unsigned int bm_position;
+    unsigned int bm_length;
+    char tlbie_test_case[20];
+    char corsa_performance[10];
+    int corsa_perf_flag;
+	int mpss_seg_size;
+    long  seg_size[MAX_PAGE_SIZES];    /* segment size in bytes*/
+    int num_cpu_filters;
+    int num_mem_filters;
+    char cpu_filter_str[MAX_FILTERS][MAX_POSSIBLE_ENTRIES];
+    char mem_filter_str[MAX_FILTERS][MAX_POSSIBLE_ENTRIES];
+    struct filter_info filter;
+
+};
+
+/**********************************************
+* Structures to hold system resource related  *
+*  information 								  *
+**********************************************/
+
+
+/*memory page wise pool segment info*/
+/*struct page_wise_seg_info {
+    unsigned long page_size;
+	unsigned int seg_num;
+    unsigned int *shmids;
+    unsigned int *shm_keys;
+    unsigned long *shm_sizes;
+    char **shr_mem_hptr;
+	unsigned int segs_per_thred_srad[MAX_CPUS_PER_SRAD];
+};*/
+
+
+/****************************************************
+*Memory exerciser specific thread structure			*
+****************************************************/
+
+struct mem_exer_thread_info{
+    int num_segs;
+	int cpu_flag;                               /*to mark,if thread is accessing any hole*/
+    int bit_mask[MAX_L4_MASKS];					 /*L4*/
+    unsigned int start_offset; 					 /*offset address for every thread in L4*/
+    struct page_wise_seg_info *seg_details;
+};
+	
+
+/*****************************************************
+*A single thread structure collective of all nest exers
+*****************************************************/
+
+struct thread_data {
+    int thread_num;
+    pthread_t tid;
+    pthread_t kernel_tid;
+    pthread_attr_t  thread_attrs;
+    int num_oper;
+    int bind_proc;	/* logical cpu number to bind*/
+    int thread_type;     /*mem,cache,fabricbus,tlbie.. etc*/
+
+    void* testcase_thread_details; /* dynamically point to test case specific thread structures*/
+	
+};
+
+/********************************************************
+*Memory exer function structure							*
+********************************************************/
+/* Structure to print the encapsulated values in KDB trap */
+struct segment_detail {
+    unsigned long oper;
+    unsigned long seg_num;
+    unsigned long page_index;
+    unsigned long width;
+    unsigned long seg_size;
+    unsigned long owning_thread;
+    unsigned long cpu_owning_chip;
+    unsigned long mem_owning_chip;
+    unsigned long affinity_index;
+    unsigned long thread_ptr_addr;
+    unsigned long global_ptr_addr;    
+    unsigned long sub_seg_num;
+    unsigned long sub_seg_size;
+    unsigned long num_times;
+};
+
+
+struct mem_exer_info {
+	int bind_proc;								/*-1 in concurrent mode, locical cpu number in normal mode*/
+	int dma_flag ; 								/* This flag is set if filesystem is diskless */
+	int affinity;  						/*flag is set when affinity test is enabled*/
+	int AME_enabled;
+	int max_mem_percent;
+    struct mem_exer_thread_info *mem_th_data;
+    unsigned long long dummy_read_data;
+    unsigned long total_segments;
+    int shm_cleanup_done;
+};
+/*******************************************************
+*GLOBAL structure:									   *
+*******************************************************/
+struct nest_global {  
+	int dev_id;
+	char rules_file_name[RULE_FILE_NAME_LENGTH];
+	time_t rf_last_mod_time; 
+	
+	pid_t pid;
+	int kdb_level;
+	int test_type;		/* any of CACHE,MEM,FABRICBUS,TLBIE etc*/
+	int exit_flag;
+	int standalone;
+	int cpu_DR_flag;
+	int mem_DR_flag;
+
+	int stanza_num; /* --- move to rule info */
+	pthread_mutex_t tmutex;/*RV1: check to remove this*/
+    int msg_n_err_logging_lock;/* Remove from and displaym function once updated with htx library */
+	FILE *rf_ptr;
+	struct sigaction sigvector; 				/* Signal handler data structure */
+	struct rule_info stanza[MAX_STANZAS];		/* stores rule file stanza info*/
+    struct global_rule gstanza;
+	struct rule_info *stanza_ptr;				/* current rule staza pointer*/
+	struct htx_data htx_d;
+	struct sys_info sys_details;				/*syscfg library provided system information*/
+    
+
+	void* test_type_ptr;						/* dynamic pointer to any of test function structers*/
+	struct thread_data *thread_ptr;
+#if 0
+	
+
+	/*struct cache_test_info  *cache_test_ptr;
+	struct fabric_test_info *fab_test_ptr;
+	struct l4_mba_test_info *l4_mba_test_ptr; 
+	<add other test case ptrs>
+	*/
+#endif
+	void *current_test_ptr;  /* dynamic pointer to any of test sub  function structers*/
+	
+
+};
+
+int test_var;
+
+int fill_exer_huge_page_requirement(void);
+void print_partition_config(void);
+int displaym(int,int , const char *,...);
+int read_rules(void);
+int mem_exer_opearation(void);
+
+void SIGCPUFAIL_handler(int,int, struct sigcontext *);
+void reg_sig_handlers(void);
+int read_cmd_line(int argc,char *argv[]);
+void get_test_type(void);
+void get_cache_details(void);
+int get_system_details(void);
+int apply_process_settings(void);
+int modify_shared_mem_limits_linux(unsigned long);
+
+#ifdef __HTX_LINUX__
+extern void SIGUSR2_hdl(int, int, struct sigcontext *);
+#endif
+
+/*Normal pattern size operation functions*/
+int mem_operation_write_dword(int,void *,void *,int,void *,void *,void *,void*);
+int mem_operation_write_word(int,void *,void *,int,void *,void *,void *,void*);
+int mem_operation_write_byte(int,void *,void *,int,void *,void *,void *,void*);
+
+int mem_operation_read_dword(int,void *,void *,int,void *,void *,void *,void*);
+int mem_operation_read_word(int,void *,void *,int,void *,void *,void *,void*);
+int mem_operation_read_byte(int,void *,void *,int,void *,void *,void *,void*);
+
+int mem_operation_comp_dword(int,void *,void *,int,void *,void *,void *,void*);
+int mem_operation_comp_word(int,void *,void *,int,void *,void *,void *,void*);
+int mem_operation_comp_byte(int,void *,void *,int,void *,void *,void *,void*);
+
+int mem_operation_rim_dword(int,void *,void *,int,void *,void *,void *,void*);
+int mem_operation_rim_word(int,void *,void *,int,void *,void *,void *,void*);
+int mem_operation_rim_byte(int,void *,void *,int,void *,void *,void *,void*);
+
+/*Big size pattern file operation functions*/
+int pat_operation_write_dword(int,void *,void *,int,void *,void *,void *,void*);
+int pat_operation_write_word(int,void *,void *,int,void *,void *,void *,void*);
+int pat_operation_write_byte(int,void *,void *,int,void *,void *,void *,void*);
+
+int pat_operation_comp_dword(int,void *,void *,int,void *,void *,void *,void*);
+int pat_operation_comp_word(int,void *,void *,int,void *,void *,void *,void*);
+int pat_operation_comp_byte(int,void *,void *,int,void *,void *,void *,void*);
+
+int pat_operation_rim_dword(int,void *,void *,int,void *,void *,void *,void*);
+int pat_operation_rim_word(int,void *,void *,int,void *,void *,void *,void*);
+int pat_operation_rim_byte(int,void *,void *,int,void *,void *,void *,void*);
+
+/*Address pattern operation functions*/
+int mem_operation_write_addr(int,void *,void *,int,void *,void *,void *,void*);
+int mem_operation_comp_addr(int,void *,void *,int,void *,void *,void *,void*);
+int mem_operation_write_addr_comp(int,void *,void *,int,void *,void *,void *,void*);
+
+/*Random type pattern operation functions*/
+int rand_operation_write_dword(int,void *,void *,int,void *,void *,void *,void*);
+int rand_operation_write_word(int,void *,void *,int,void *,void *,void *,void*);
+int rand_operation_write_byte(int,void *,void *,int,void *,void *,void *,void*);
+
+int rand_operation_comp_dword(int,void *,void *,int,void *,void *,void *,void*);
+int rand_operation_comp_word(int,void *,void *,int,void *,void *,void *,void*);
+int rand_operation_comp_byte(int,void *,void *,int,void *,void *,void *,void*);
+
+int rand_operation_rim_dword(int,void *,void *,int,void *,void *,void *,void*);
+int rand_operation_rim_word(int,void *,void *,int,void *,void *,void *,void*);
+int rand_operation_rim_byte(int,void *,void *,int,void *,void *,void *,void*);
+
+/*nstride operation related functions*/
+int do_stride_operation(int);
+int write_dword(void*, int,int,int, unsigned int*);
+int read_dword(void*,int,int);
+int read_comp_dword(void*,int,int, int, unsigned int*,int,struct segment_detail*);
+int write_word(void*,int,int,int,unsigned int*);
+int read_word(void*,int,int);
+int read_comp_word(void*,int,int,int,unsigned int*,int,struct segment_detail*);
+int write_byte(void*,int,int,int,unsigned int*);
+int read_byte(void*,int,int);
+int read_comp_byte(void*,int,int,int,unsigned int*,int,struct segment_detail*);
+#ifdef __HTX_LINUX__
+int do_trap_htx64 (unsigned long arg1,
+                       unsigned long arg2,
+                       unsigned long arg3,
+                       unsigned long arg4,
+                       unsigned long arg5,
+                       unsigned long arg6,
+                       unsigned long arg7);
+#endif
+

--- a/bin/hxemem64/nest_read_rules.c
+++ b/bin/hxemem64/nest_read_rules.c
@@ -1,0 +1,1197 @@
+/* IBM_PROLOG_BEGIN_TAG */
+/*
+ * Copyright 2003,2016 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "nest_framework.h"
+
+struct rule_info r;
+extern struct mem_exer_info mem_g;
+extern struct nest_global g_data;
+
+void free_pattern_buffers(void);
+/*****************************************************************************
+ *  This routine sets the default values for the specified rule stanza. You  *
+ *  will need to modify it to suit your needs.                               *
+ ****************************************************************************/
+void set_defaults(void)
+{
+    strcpy(r.rule_id,"");
+    strcpy(r.pattern_id,"        ");
+    r.num_oper = 1;
+    r.num_writes = 1;
+    r.disable_cpu_bind = 0;
+    r.num_reads = 1;
+    r.num_compares = 1;
+    r.num_threads= -1;
+    r.percent_hw_threads = 10;
+    r.random_bind = 0;
+    r.affinity = LOCAL;
+    strcpy(r.oper,"MEM");
+    r.operation = OPER_MEM;
+    strcpy(r.compare,"YES");
+    r.compare_flag = 1;
+    strcpy(r.crash_on_mis,"YES");
+    r.misc_crash_flag = 1;
+    strcpy(r.turn_attn_on,"NO");
+    r.attn_flag = 0;
+    r.width = LS_DWORD;
+	r.mem_percent = DEFAULT_MEM_PERCENT;
+	r.cpu_percent = DEFAULT_CPU_PERCENT;
+    r.debug_level = 0;
+    r.num_patterns = 0;
+    strcpy(r.pattern_name[0]," ");
+    r.nx_rem_th_flag = 1;
+    r.nx_perf_flag = 0;
+    r.nx_async_flag = 0;
+    r.stride_sz = 128;
+    r.mem_l4_roll = 134217728;
+    r.bm_position = 7;
+    r.bm_length = 2;
+    r.mcs_mask = -1;
+    r.seed = 0; 
+    strcpy(r.tlbie_test_case,"RAND_TLB");
+    strcpy(r.cpu_filter_str[0],"N*P*C*T*");
+    strcpy(r.mem_filter_str[0],"N*P*[4K_100%,64K_100%,2M_100%,16M_100%]");
+    r.num_mem_filters = 1;
+    r.num_cpu_filters = 1;
+    for(int i=0;i<MAX_PAGE_SIZES;i++){
+        r.seg_size[i] = -1;
+    }
+}
+
+/*****************************************************************************
+*  This routine reads a line from "stdin" into the specified string.  It     *
+*  returns the length of the string. If the length is 1 the line is blank.   *
+*  When it reaches EOF the length is set to 0,                               *
+*****************************************************************************/
+int get_line( char s[], int lim, FILE *fp)
+{
+    int c=0,i;
+
+    i=0;
+    while (--lim > 0 && ((c = fgetc(fp)) != EOF) && c != '\n') {
+        s[i++] = c;
+     }
+    if (c == '\n')
+        s[i++] = c;
+    s[i] = '\0';
+     return(i);
+}
+
+/************************************************************************* 
+FUNCTION int fill_pattern_details(int pi , char *str, int *line)		 *
+ *      pi : pattern index in the rules stanza							 *	
+ *     str : pattern name string										 *
+ *    line : pointer to line number currently parsed in the rules file	 *
+*************************************************************************/
+int fill_pattern_details(int pi, char *str, int *line)
+{
+    char tmp_str[32],buff[128],*pstr=&buff[0],**ptr=&pstr,*strptr;
+    int len  = 0, i,res=0;
+    unsigned long val = 0;
+    debug(HTX_HE_INFO,DBG_INFO_PRINT,"#fill_pattern_details: pi=%d,str=%s,line=%d\n",\
+                pi,str,*line);
+
+    /*strncpy(r.pattern_name[pi],str,66);*/
+    if( strncmp(str,"0X",2) == 0 ) {
+        if (strcmp(r.oper,"DMA")==0){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT, "[%d]%s:line#%d pattern = %s "
+                     "(DMA oper cannot have HEX pattern like 0xBEEFDEAD)\nOnly file"
+                    "name is allowed in pattern field.\n",__LINE__,__FUNCTION__,*line, str);
+        }
+        /* Pattern is specified as a HEX immediate value like 0xFFFFFFFF */
+        len=strlen(str);
+        len = len - 2;
+        if (len == 0) {
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:HEX pattern cannot be zero sized\n",__LINE__,__FUNCTION__);
+            /*re_initialize_global_vars();*/
+            exit(1);
+        }
+        if ( len%16 != 0 ) {
+            /* Pattern should be multiple of 8 bytes i.e, 16 characters */
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:#line %d: %s pattern value "
+                "should be in multiple of 8 bytes \n",__LINE__,__FUNCTION__,*line,str);
+            return(1);
+        }
+        /* Fill the size of the pattern */
+        r.pattern_size[pi]=len/2; /* 0xFF 2 characters is 1 byte */
+        if ( (r.pattern_size[pi]) & (r.pattern_size[pi]-1)) {
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:#line %d: %s pattern's length "
+                "should be power of 2 bytes\n",__LINE__,__FUNCTION__,*line,str);
+            return(1);
+        }
+        r.pattern[pi]=(char *) malloc(r.pattern_size[pi]);
+        if (r.pattern[pi] == NULL ) {
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:#line %d: %s pattern value,"
+                    " pattern buffer malloc error - %d (%s)\n",__LINE__,__FUNCTION__,*line,str,errno,strerror(errno));
+        }
+
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"#fill_pattern_details: len =%d\n",len);
+        str=str+2;
+        i = 0;
+        while (i < len) {
+            strncpy(tmp_str,str,16);
+            tmp_str[16]='\0';
+            val=strtoul(tmp_str,NULL,16);
+            if (val == 0) {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:#line %d: %s pattern is not "
+                        "proper hex value\n",__LINE__,__FUNCTION__,*line,str);
+            }
+            debug(HTX_HE_INFO,DBG_INFO_PRINT,"#fill_pattern_details: val =0x%lx\n",val);
+            *(unsigned long *)(&r.pattern[pi][8*(i/16)])=val;
+            i=i+16;
+            str=str+16;
+        }
+        if (r.pattern_size[pi] > MIN_PATTERN_SIZE ) {
+            r.pattern_type[pi]= PATTERN_SIZE_BIG;
+        } else {
+            r.pattern_type[pi]= PATTERN_SIZE_NORMAL;
+        }
+
+        for (i=0; i<r.pattern_size[pi]; i++) {
+            debug(HTX_HE_INFO,DBG_INFO_PRINT,"-%x-",r.pattern[pi][i]);
+        }
+    }
+    else {
+        strptr=strtok_r(str,"()",ptr);
+        strptr=strtok_r(NULL,"()",ptr);
+        if (strptr!=NULL){
+            val=atoi(strptr);
+               debug(HTX_HE_INFO,DBG_INFO_PRINT,"#fill_pattern_details:In (%s) size of patttern "
+                "to be extracted specified as %d\n",strptr,val);
+            /* Size of the pattern cannot be specified for RANDOM and ADDRESS patterns*/
+            if ((strcmp(r.pattern_name[pi],"RANDOM")==0 )&& (strcmp(r.pattern_name[pi],"ADDRESS")==0)) {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:#line %d: %s Size of the pattern cannot"
+                        " be specified for RANDOM and ADDRESS patterns \n",__LINE__,__FUNCTION__,*line,str);
+                return(1);
+                /* Fill the size of the pattern with default value */
+            }
+            r.pattern_size[pi]=val;
+        }
+        else {
+            if ((strcmp(r.pattern_name[pi],"RANDOM")!=0 )&& (strcmp(r.pattern_name[pi],"ADDRESS")!=0)) {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:#line %d: %s pattern's length "
+                    "should be specified with the pattern file name \n",__LINE__,__FUNCTION__,*line,str);
+                return(1);
+                /* Fill the size of the pattern with default value */
+            }
+            /* If pattern is ADDRESS or RANDOM, size is assigned as 8 */
+            r.pattern_size[pi] = MIN_PATTERN_SIZE;
+        }
+        if ( (r.pattern_size[pi]) & (r.pattern_size[pi]-1)) {
+            displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,
+                     "[%d]%s:#line %d: %s pattern's length should be power of "
+                     "2 bytes\n",__LINE__,__FUNCTION__, *line, str);
+            return(1);
+        }
+        if (r.pattern_size[pi] > MAX_PATTERN_SIZE ||
+            r.pattern_size[pi] < MIN_PATTERN_SIZE) {
+                displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,
+                         "[%d]%s:#line %d: %s pattern has improper pattern size "
+                         "(should be 8 <= size <= 4096)\n",__LINE__,__FUNCTION__,*line, str);
+                return(1);
+        } else {
+            if (r.pattern_size[pi] % MIN_PATTERN_SIZE != 0) {
+                displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,
+                         "[%d]%s:#line %d: %s pattern has improper pattern size "
+                         "(should multiple of 8 bytes)\n",__LINE__,__FUNCTION__, *line, str);
+                return(1);
+            }
+            r.pattern[pi]=(char *) malloc(r.pattern_size[pi]);
+            if (r.pattern[pi] == NULL ) {
+                displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,
+                        "[%d]%s:#line %d: %s pattern value, pattern buffer malloc "
+                        "error - %d (%s)\n",__LINE__,__FUNCTION__,*line, str, errno, strerror(errno));
+            }
+            char* pat_tmp_ptr = getenv("HTXPATTERNS");
+            if(pat_tmp_ptr == NULL){
+                displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,"[%d]%s(): env variable HTXPATTERNS is not set,pat_tmp_ptr=%p"
+                ", thus exiting..\n",__LINE__,__FUNCTION__,pat_tmp_ptr);
+                return (-1);
+
+            }else{
+                strcpy(buff,pat_tmp_ptr);
+            }
+            strcat(buff,r.pattern_name[pi]);
+            debug(HTX_HE_INFO, DBG_INFO_PRINT,
+                     "#fill_pattern_details:In (pattern name = %s) size = %d\n",
+                     buff, r.pattern_size[pi]);
+            if (strcmp(r.pattern_name[pi],"ADDRESS") != 0 &&
+                strcmp(r.pattern_name[pi],"RANDOM") != 0) {
+				res = hxfpat(buff, (char *)&r.pattern[pi][0],r.pattern_size[pi]);
+                     if(res != 0) {
+                    displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT,
+                             "[%d]%s:pattern fetching problem -error - %d",__LINE__,__FUNCTION__, res);
+                    return(1);
+                }
+                if (r.pattern_size[pi] > MIN_PATTERN_SIZE ) {
+                    r.pattern_type[pi] = PATTERN_SIZE_BIG;
+                } else {
+                    r.pattern_type[pi] = PATTERN_SIZE_NORMAL;
+                }
+            } else {
+                if (strcmp(r.pattern_name[pi],"ADDRESS") == 0) {
+                    *(unsigned long *)r.pattern[pi] = ADDR_PAT_SIGNATURE;
+                    r.pattern_type[pi] = PATTERN_ADDRESS;
+                } else {
+                    *(unsigned long *)r.pattern[pi] = RAND_PAT_SIGNATURE;
+                    r.pattern_type[pi] = PATTERN_RANDOM;
+                }
+            }
+        }
+    }
+    return(0);
+}
+/*****************************************
+*Frees pattern structure allocations	 *
+*****************************************/
+void free_pattern_buffers()
+{
+    struct rule_info *stnza_ptr=&g_data.stanza[0];
+    int i=0;
+
+    while( strcmp(stnza_ptr->rule_id,"NONE") != 0)
+    {
+        for (i=0; i< stnza_ptr->num_patterns; i++){
+            if ( stnza_ptr->pattern[i]){
+                free(stnza_ptr->pattern[i]);
+                stnza_ptr->pattern[i]=NULL;
+            }
+			printf("###########...%d\n",i);
+            strcpy(stnza_ptr->pattern_name[i],"\0");
+            stnza_ptr->pattern_size[i]=0;
+        }
+        stnza_ptr++;
+    }
+}
+
+
+
+
+
+/*****************************************************************************
+*  for each keyword parameter of the rule stanza:                            *
+*    1. assign default value to corresponding program variable.              *
+*    2. assign specified value to corresponding program variable.            *
+*    3. validity check each variable.                                        *
+*                                                                            *
+*  return code =  0 valid stanza                                             *
+*              =  1 invalid stanza                                           *
+*              = -1 EOF                                                      *
+*****************************************************************************/
+int get_rule(int * line, FILE *fp)
+{
+    char  s[MAX_RULE_LINE_SIZE],buff[500],*pstr=&buff[0],**ptr=&pstr;
+    char  keywd[80];
+    int   i,j;
+    int   keywd_count;         /* keyword count                               */
+    int   rc;                  /* return code                                 */
+    int   first_line;          /* line number of first keyword in stanza      */
+
+
+    /* Set the default values in the stanza pointer variable */
+    set_defaults();
+    keywd_count = 0;
+    first_line = *line + 1;
+    while ((get_line(s,MAX_RULE_LINE_SIZE,fp)) > 1)
+    {
+        *line = *line + 1;
+        if (s[0] == '*')
+            continue;
+
+        for (i=0; s[i]!='\n' && s[i] != '\0'; i++) {
+            s[i] = toupper(s[i]);
+            if (s[i] == '=')
+                s[i] = ' ';
+        } /* endfor */
+
+        keywd_count++;
+        sscanf(s,"%s",keywd);
+
+        if((strcmp(keywd,"GLOBAL_ALLOC_MEM_PERCENT"))== 0) {
+            sscanf(s,"%*s %u",&g_data.gstanza.global_alloc_mem_percent); 
+            if((g_data.gstanza.global_alloc_mem_percent<=0) && (g_data.gstanza.global_alloc_mem_percent>= 100)){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %s"
+                        " must be greater than 0 and less than 100",*line,keywd,r.rule_id);
+                exit(1);
+            }
+        }else if((strcmp(keywd,"GLOBAL_MEM_4K_USE_PERCENT"))== 0) {
+            sscanf(s,"%*s %u",&g_data.gstanza.global_mem_4k_use_percent); 
+            if((g_data.gstanza.global_mem_4k_use_percent <=0) && (g_data.gstanza.global_mem_4k_use_percent > 100)){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %s"
+                        " must be greater than 0 and less than equal to 100",*line,keywd,r.rule_id);
+                exit(1);
+            }
+        }else if((strcmp(keywd,"GLOBAL_MEM_64K_USE_PERCENT"))== 0) {
+            sscanf(s,"%*s %u",&g_data.gstanza.global_mem_64k_use_percent); 
+            if((g_data.gstanza.global_mem_64k_use_percent <=0) && (g_data.gstanza.global_mem_64k_use_percent > 100)){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %s"
+                        " must be greater than 0 and less than equal to 100",*line,keywd,r.rule_id);
+                exit(1);
+            }
+        }else if((strcmp(keywd,"GLOBAL_ALLOC_MEM_SIZE"))==0){
+            sscanf(s,"%*s %ld",&g_data.gstanza.global_alloc_mem_size);
+            if(g_data.gstanza.global_alloc_mem_size<=0) {
+               displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %s"
+                    " must be greater than 0",*line,keywd,r.rule_id);
+                exit(1); 
+            }
+        }else if((strcmp(keywd,"GLOBAL_ALLOC_SEGMENT_SIZE"))==0){
+            sscanf(s,"%*s %ld",&g_data.gstanza.global_alloc_segment_size);
+            if(g_data.gstanza.global_alloc_segment_size <=0) {
+               displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %s"
+                    " must be greater than 0",*line,keywd,r.rule_id);
+                exit(1); 
+            }
+        }else if((strcmp(keywd,"GLOBAL_DISABLE_FILTERS"))==0){
+			char bp[20];
+			(void) sscanf(s,"%*s %s",bp);
+			if (strcmp(bp,"NO") == 0 ) {
+				g_data.gstanza.global_disable_filters = 0;
+			}else if (strcmp(bp,"YES") == 0) {
+				g_data.gstanza.global_disable_filters = 1;
+			}else{
+				displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s =%s "
+					"(must be NO or YES)\n",*line, keywd, bp);
+                exit(1); 
+            }
+        }else if((strcmp(keywd,"GLOBAL_ALLOC_HUGE_PAGE"))==0){
+			char bp[20];
+			(void) sscanf(s,"%*s %s",bp);
+			if (strcmp(bp,"NO") == 0 ) {
+				g_data.gstanza.global_alloc_huge_page = 0;
+			}else if (strcmp(bp,"YES") == 0) {
+				g_data.gstanza.global_alloc_huge_page = 1;
+			}else{
+				displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s =%s "
+					"(must be NO or YES)\n",*line, keywd, bp);
+                exit(1); 
+            }
+        }else if((strcmp(keywd,"GLOBAL_NUM_THREADS"))== 0) {
+			sscanf(s,"%*s %d",&g_data.gstanza.global_num_threads); 
+			if((g_data.gstanza.global_num_threads<0) && (g_data.gstanza.global_num_threads>g_data.sys_details.tot_cpus)){
+				displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %s"
+						" must be greater than 0 and less than total cppus=%d",*line,keywd,r.rule_id,g_data.sys_details.tot_cpus);
+				exit(1);
+			}
+        }
+        else if((strcmp(keywd,"GLOBAL_DEBUG_LEVEL"))== 0) {
+            if(!g_data.standalone){
+                sscanf(s,"%*s %d",&g_data.gstanza.global_debug_level); 
+                if((g_data.gstanza.global_debug_level<0) && (g_data.gstanza.global_debug_level>4)){
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %s"
+                            " must be greater than 0 and less than 4",*line,keywd,r.rule_id);
+                    exit(1);
+                }
+            }
+        }
+        else if((strcmp(keywd,"GLOBAL_DISABLE_CPU_BIND"))== 0) {
+            char bp[20];
+            (void) sscanf(s,"%*s %s",bp);
+            if (strcmp(bp,"NO") == 0 ) {
+                g_data.gstanza.global_disable_cpu_bind= 0;
+            }else if (strcmp(bp,"YES") == 0) {
+                g_data.gstanza.global_disable_cpu_bind= 1;
+            }
+            else {
+                 displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s =%s "
+                         "(must be NO or YES)\n",*line, keywd, bp);
+
+                exit(1);
+            }
+        }
+        else if ((strcmp(keywd,"GLOBAL_STARTUP_DELAY")) == 0)
+        {
+            sscanf(s, "%*s %d", &g_data.gstanza.global_startup_delay);
+            if ((g_data.gstanza.global_startup_delay < 0) || (g_data.gstanza.global_startup_delay > 120)) {
+                displaym(HTX_HE_HARD_ERROR, DBG_MUST_PRINT, "line# %d %s = %d "
+                        " (startup_delay must be >= 0 and <= 120 seconds)\n",
+                         *line, keywd, g_data.gstanza.global_startup_delay);
+                exit(1);
+            }              /* endif */
+        }
+        else if ((strcmp(keywd,"RULE_ID")) == 0) {
+                sscanf(s,"%*s %s",r.rule_id);
+                if ((strlen(r.rule_id)) > 24) {
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %s"
+                            " (must be 8 characters or less)\n",*line,keywd,\
+                            r.rule_id);
+                    exit(1);
+                } /* endif */
+        }
+        else if ((strcmp(keywd,"PATTERN_ID")) == 0)
+        {
+            char *tmp_str;
+            int i = 0;
+
+            tmp_str=strtok_r(s," \n",ptr);
+            while (tmp_str != NULL && i <= 9 ){
+                tmp_str=strtok_r(NULL," \n",ptr);
+                debug(HTX_HE_INFO,DBG_INFO_PRINT,"#tmp_str (%d) = %s\n",\
+                        i,tmp_str);
+                if (tmp_str == NULL ) {
+                    break;
+                }
+                /* Ignore RANDOM pattern if AME is enabled as random pattern reduces performance of AME enabled system */
+                if ((mem_g.AME_enabled == 1)&& (strcmp(tmp_str, "RANDOM") == 0)) {
+                    displaym(HTX_HE_INFO, DBG_MUST_PRINT, "AME is enabled on system, hence ignoring RANDOM pattern as it degrades the performance.\n");
+                    continue;
+                }
+                if ((strlen(tmp_str)) > 66) {
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %s (must "
+                            "be 34 characters or less)\n",s);
+                }
+                strcpy(r.pattern_name[i],tmp_str);
+                if ( fill_pattern_details(i,r.pattern_name[i],line) != 0 ) {
+                    exit(1);
+                }
+                i++;
+            }
+            if (tmp_str) {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %s (more than "
+                        "10 patterns cannot be specified in a single rule\n",s);
+            }
+            if ( i ) {
+                r.num_patterns = i;
+            }
+            else {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line#%d %s (pattern not"
+                    " specified properly )\n",*line,s);
+                exit(1);
+            }
+
+            debug(HTX_HE_INFO,DBG_INFO_PRINT,"num of patterns = %d\n",\
+                    r.num_patterns );
+
+            if ((strcmp(r.oper,"DMA")==0)&&(r.num_patterns > 1)){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT, "line#%d %s "
+                     "(DMA oper cannot have more than one pattern)\n",*line, s);
+                exit(1);
+            }
+
+            for (i=0; i<r.num_patterns; i++) {
+                debug(HTX_HE_INFO,DBG_INFO_PRINT,"pattern name = %s\n "
+                        "pattern_size =%d\npattern =0x",r.pattern_name[i],\
+                        r.pattern_size[i]);
+                if ((strcmp(r.oper,"DMA")==0) && ((strcmp(r.pattern_name[i],"ADDRESS")==0)\
+                        || (strcmp(r.pattern_name[i],"RANDOM")==0))) {
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT, "line#%d %s = %s "
+                     "(DMA oper cannot have ADDRESS or RANDOM pattern test case in "
+                     "the rules file %s)\n",*line,keywd,r.pattern_name[i],\
+                     g_data.rules_file_name);
+                    exit(1);
+                }
+                for (j=0; j<r.pattern_size[i]; j++) {
+                    debug(HTX_HE_INFO,DBG_INFO_PRINT,"%0x",r.pattern[i][j]);
+                }
+                debug(HTX_HE_INFO,DBG_INFO_PRINT,"\n");
+            }
+
+        }/*if (strcmp(keywd,pattern_id... ends */
+        else if (strcmp(keywd,"SEED")==0) {
+            char seed_str[128];
+            (void) sscanf(s,"%*s %s",seed_str);
+            if ((strncmp(seed_str,"0X",2) != 0)||( strlen(seed_str) > 18 )) {
+                 displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s =%s " "(must enter hexadecimal (like 0x456) which is less "
+                        "or equal to 8 bytes\n",*line,keywd,seed_str);
+            }else { 
+                (void) sscanf(seed_str,"0X%lu",&r.seed);
+            }        
+        }
+        else if ((strcmp(keywd,"NUM_OPER")) == 0)
+        {
+            sscanf(s,"%*s %d", &r.num_oper);
+            if (r.num_oper < 1) {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %d "
+                        "(must be 1 or greater) \n",*line,keywd,r.num_oper);
+                exit(1);
+            } /* endif */
+        }
+        else if (strcmp(keywd,"NUM_THREADS")==0) {
+            int num_proc=0;
+            sscanf(s,"%*s %d",&r.num_threads);
+            num_proc = g_data.sys_details.tot_cpus;/*############### need change, include syscfg call*/
+            if ((r.num_threads < 1) || (r.num_threads > num_proc)) {
+                     displaym(HTX_HE_INFO,DBG_MUST_PRINT,"line# %d %s = %ld "
+                         "(num of threads not in valid range(<%d))\nAdjusting"
+                         "it to %d",*line,keywd, r.num_threads,\
+                         num_proc,num_proc);
+            }
+        }
+        else if ((strcmp(keywd,"OPER"))== 0)
+        {
+            int i = 0;
+            (void) sscanf(s,"%*s %s",r.oper);
+            if (strcmp(r.oper,"MEM") == 0 ) {
+                r.operation=OPER_MEM;
+            } else if (strcmp(r.oper,"DMA") == 0 ) {
+                r.operation=OPER_DMA;
+            } else if ( strcmp(r.oper,"RIM") == 0 ) {
+                r.operation=OPER_RIM;
+            } else if ( strcmp(r.oper,"TLB") == 0 ) {
+                r.operation=OPER_TLB;
+            } else if ( strcmp(r.oper,"MPSS") == 0) {
+                r.operation=OPER_MPSS;
+            } else if (strcmp(r.oper, "STRIDE") == 0) {
+                r.operation=OPER_STRIDE;
+            } else if (strcmp(r.oper, "L4_ROLL") == 0) {
+                r.operation=OPER_L4_ROLL;
+            } else if (strcmp(r.oper, "MBA") == 0) {
+                r.operation=OPER_MBA;
+            }
+            else {
+                 displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT, "line# %d %s =%s \
+                         (must be MEM/DMA/RIM/TLB/MPSS/STRIDE)\n",*line,\
+                         keywd, r.oper);
+                  exit(1);
+            } /* end else */
+            if ((strcmp(r.oper,"DMA")==0) && ((r.num_patterns > 1) || \
+                    (strncmp(r.pattern_name[0],"0X",2)==0))){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT, "line#%d %s "
+                     "(DMA oper cannot have more than one pattern)\n",*line, s);
+                exit(1);
+            }
+            for (i=0; i<r.num_patterns; i++) {
+                if ((strcmp(r.oper,"DMA")==0) && ((strcmp(r.pattern_name[i],"ADDRESS")==0)\
+                            || (strcmp(r.pattern_name[i],"RANDOM")==0))) {
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT, "line#%d %s = %s "
+                             "(DMA oper cannot have ADDRESS or RANDOM pattern test case in "
+                             "the rules file %s)\n",*line,keywd,r.oper,\
+                             g_data.rules_file_name);
+                    exit(1);
+                }
+            }
+        }
+        else if ((strcmp(keywd,"DISABLE_CPU_BIND"))== 0)
+        {
+            char bp[20];
+            (void) sscanf(s,"%*s %s",bp);
+            if (strcmp(bp,"NO") == 0 ) {
+                r.disable_cpu_bind= 0;
+            }else if (strcmp(bp,"YES") == 0) {
+                r.disable_cpu_bind= 1;
+            }
+            else {
+                 displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s =%s "
+                         "(must be NO or YES)\n",*line, keywd, bp);
+                  exit(1);
+            } /* end else */
+        }
+    else if ((strcmp(keywd,"RANDOM_BIND"))== 0)
+       {
+           char bm[20];
+           (void) sscanf(s,"%*s %s",bm);
+             if (strcmp(bm,"NO") == 0 ) {
+                 r.random_bind = 0;
+             }else if (strcmp(bm,"YES") == 0) {
+                 r.random_bind= 1;
+             }
+             else {
+                  displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s =%s "
+                          "(must be BIND_RANDOM  or BIND_FIXED)\n",*line, keywd, bm);
+                   exit(1);
+             } /* end else */
+        }
+    else if ((strcmp(keywd,"AFFINITY"))== 0)
+       {
+           char ay[20];
+           (void) sscanf(s,"%*s %s",ay);
+            if (strcmp(ay,"LOCAL") == 0 ) {
+                 r.affinity = LOCAL;
+            }else if((strcmp(ay,"REMOTE_CHIP") == 0 )) {
+                r.affinity = REMOTE_CHIP;
+             }else if((strcmp(ay,"FLOATING") == 0 )) {
+                 r.affinity = FLOATING;
+             }else if((strcmp(ay,"INTRA_NODE") == 0 )) {
+                 r.affinity = INTRA_NODE;
+             }else if((strcmp(ay,"INTER_NODE") == 0 )) {
+                 r.affinity = INTER_NODE;
+             }else {
+                  displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s =%s "
+                          "(must be any of : LOCAL/REMOTE_CHIP/FLOATING/INTRA_NODE/INTER_NODE)\n",*line, keywd, ay);
+                  exit(1);
+             } /* end else */
+            if((r.affinity==REMOTE_CHIP || r.affinity==INTRA_NODE || r.affinity==INTER_NODE) && (g_data.sys_details.num_chip_mem_pools <= 1)){
+                displaym(HTX_HE_INFO,DBG_MUST_PRINT,
+                    "partition has %d num of chips, (line# %d %s =%s) need atleast 2 chips,change "
+                    "affinity setting  will be overwritten to  LOCAL in %s file.\n",
+                    g_data.sys_details.num_chip_mem_pools,*line,keywd,ay,g_data.rules_file_name);
+                    r.affinity = LOCAL;
+            }
+        }
+
+        else if ((strcmp(keywd,"SWITCH_PAT_PER_SEG"))== 0)
+        {
+            char sp[20];
+            (void) sscanf(s,"%*s %s",sp);
+            if (strcmp(sp,"NO") == 0 ) {
+                r.switch_pat = SW_PAT_OFF;
+            }else if (strcmp(sp,"YES") == 0) {
+                r.switch_pat = SW_PAT_ON;
+            }else if (strcmp(sp,"ALL") == 0) {
+                r.switch_pat = SW_PAT_ALL;
+            }
+            else {
+                 displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s =%s "
+                         "(must be NO or YES)\n",*line, keywd, sp);
+                  exit(1);
+            } /* end else */
+        }
+        else if ((strcmp(keywd,"COMPARE"))== 0)
+        {
+            (void) sscanf(s,"%*s %s",r.compare);
+            if (strcmp(r.compare,"NO") == 0 ) {
+                r.compare_flag = 0;
+            } else if ( strcmp(r.compare,"YES") == 0 ) {
+                r.compare_flag = 1;
+            }
+            else {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s =%s "
+                         "(must be NO or YES)\n",*line, keywd, r.compare);
+                exit(1);
+            } /* end else  */
+        }
+        else if ((strcmp(keywd,"NUM_WRITES")) == 0)
+        {
+            sscanf(s,"%*s %d", &r.num_writes);
+            if ((r.num_writes < 0) )
+            {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %ld "
+                        "(num_writes should be > 0)\n",*line, keywd, \
+                        r.num_writes);
+                exit(1);
+            }              /* end else */
+        }
+        else if ((strcmp(keywd,"NUM_READ_ONLY")) == 0)
+        {
+            sscanf(s,"%*s %d", &r.num_reads);
+            if ((r.num_reads < 0) )
+            {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %ld "
+                        "(segment size not in valid range)\n",*line, keywd, \
+                        r.num_reads);
+                exit(1);
+            }              /* end else */
+        }
+        else if ((strcmp(keywd,"NUM_READ_COMP")) == 0)
+        {
+            sscanf(s,"%*s %d", &r.num_compares);
+            if ((r.num_compares < 0) )
+            {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %ld "
+                        "(segment size not in valid range)\n",*line, keywd, \
+                        r.num_compares);
+                exit(1);
+            }              /* end else */
+        }
+        else if ((strcmp(keywd,"MEM_PERCENT")) == 0)
+        {
+            sscanf(s,"%*s %d",&r.mem_percent);
+            if (r.mem_percent < MIN_MEM_PERCENT) {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %d "
+                         "(mem_percent must be >= %d%)\n",*line, keywd,\
+                         r.mem_percent, MIN_MEM_PERCENT);
+                exit(1);
+            }              /* endif */
+        }
+        else if ((strcmp(keywd,"CPU_PERCENT")) == 0)
+        {
+            sscanf(s,"%*s %d",&r.cpu_percent);
+            if (r.cpu_percent < MIN_CPU_PERCENT) {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %d "
+                         "(mem_percent must be >= %d%)\n",*line, keywd,\
+                         r.mem_percent, MIN_CPU_PERCENT);
+                exit(1);
+            }              /* endif */
+        }
+        else if ((strcmp(keywd,"WIDTH")) == 0)
+        {
+            sscanf(s,"%*s %d",&r.width);
+            if ((r.width != LS_BYTE) &&
+                (r.width != LS_WORD) &&
+                (r.width != LS_DWORD)) {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %d"
+                        " (width must be 1, 4, or 8)\n",*line, keywd, r.width);
+                exit(1);
+            }              /* endif */
+        }
+        else if ((strcmp(keywd,"DEBUG_LEVEL")) == 0)
+        {
+            sscanf(s,"%*s %d",&r.debug_level);
+            if ((r.debug_level < 0) || (r.debug_level > 3 ) ) {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %d "
+                        " (debug_level must be >= 0 and <= 3)\n",*line, keywd,\
+                        r.debug_level);
+                exit(1);
+            }              /* endif */
+        }
+        else if ((strcmp(keywd,"SEG_SIZE_4K")) == 0)
+        {
+            sscanf(s,"%*s %ld", &r.seg_size[PAGE_INDEX_4K]);
+            if (r.seg_size[PAGE_INDEX_4K] < MIN_SEG_SIZE)
+            {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %ld "
+                        "(segment size not in valid range)\n",*line, keywd, \
+                        r.seg_size[PAGE_INDEX_4K]);
+                exit(1);
+            }              /* end else */
+        }
+        else if ((strcmp(keywd,"SEG_SIZE_64K")) == 0)
+        {
+            sscanf(s,"%*s %ld", &r.seg_size[PAGE_INDEX_64K]);
+            if (r.seg_size[PAGE_INDEX_64K] < MIN_SEG_SIZE)
+            {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %ld "
+                        "(segment size not in valid range)\n",*line, keywd, \
+                        r.seg_size[PAGE_INDEX_64K]);
+                exit(1);
+            }              /* end else */
+        }
+        else if ((strcmp(keywd,"SEG_SIZE_2M")) == 0)
+        {
+            sscanf(s,"%*s %ld", &r.seg_size[PAGE_INDEX_2M]);
+            if (r.seg_size[PAGE_INDEX_2M] < MIN_SEG_SIZE)
+            {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %ld "
+                        "(segment size not in valid range)\n",*line, keywd, \
+                        r.seg_size[PAGE_INDEX_2M]);
+                exit(1);
+            }              /* end else */
+        }
+        else if ((strcmp(keywd,"SEG_SIZE_16M")) == 0)
+        {
+            sscanf(s,"%*s %ld", &r.seg_size[PAGE_INDEX_16M]);
+            if (r.seg_size[PAGE_INDEX_16M] < MIN_SEG_SIZE)
+            {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %ld "
+                        "(segment size not in valid range)\n",*line, keywd, \
+                        r.seg_size[PAGE_INDEX_16M]);
+                exit(1);
+            }              /* end else */
+        }
+        else if ((strcmp(keywd,"SEG_SIZE_16G")) == 0)
+        {
+            sscanf(s,"%*s %ld", &r.seg_size[PAGE_INDEX_16G]);
+            if ((unsigned long) r.seg_size[PAGE_INDEX_16G] <
+                (unsigned long)(16*GB))
+            {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"line# %d %s = %ld "
+                        "(segment size not in valid range)\n", *line, keywd,\
+                        r.seg_size[PAGE_INDEX_16G]);
+                exit(1);
+            }              /* end else */
+        }
+#if 0
+             else if ((strcmp(keywd,"NX_PERFORMANCE_DATA")) == 0)
+            {
+                    sscanf(s,"%*s %s",r.nx_performance_data);
+                    if ((strcmp(r.nx_performance_data,"NO")) == 0) {
+                        r.nx_perf_flag = 0;
+                    }
+                    else {
+                        r.nx_perf_flag = 1;
+                    }
+            }
+             else if ((strcmp(keywd,"NX_ASYNC")) == 0)
+            {
+                    sscanf(s,"%*s %s",r.nx_async);
+                    if ((strcmp(r.nx_async,"NO")) == 0) {
+                        r.nx_async_flag= 0;
+                    }
+                    else {
+                        r.nx_async_flag= 1;
+                    }
+            }
+             else if ((strcmp(keywd,"NX_REMINDER_THREADS_FLAG")) == 0)
+            {
+                    sscanf(s,"%*s %s",r.nx_reminder_threads_flag);
+                    if ((strcmp(r.nx_reminder_threads_flag,"NO")) == 0) {
+                    r.nx_rem_th_flag = 0;
+                    }
+                    else {
+                r.nx_rem_th_flag = 1;
+                    }
+            }
+        else if ((strcmp(keywd,"NX_MEM_OPERATIONS"))== 0)
+                {
+            displaym(HTX_HE_INFO,DBG_INFO_PRINT,"INSIDE NX_MEM_OPERATIONS\n");
+            char *chr_ptr, *str1, tmp_buf[100];
+            char  *s1, *s2;
+            int task = 0, field = 0, val;
+            float valf;
+            str1 = s;
+
+            while((task < MAX_NX_TASK) && (str1 != NULL)){
+                chr_ptr = strsep(&str1, "[");
+                if(str1 != NULL) {
+
+                    s1 = strsep(&str1, "]");
+                    if(str1 != NULL) {
+                        strcpy(tmp_buf, s1);
+                        displaym(HTX_HE_INFO,DBG_INFO_PRINT,"s1 = %s \n",s1);
+                    }
+                    else {
+                        displaym(HTX_HE_INFO,DBG_INFO_PRINT,"# task = %d \t tmp_buf  = %s\n",
+                        task,tmp_buf);
+                        return(-1);
+                    }
+
+                }
+                else {
+                    displaym(HTX_HE_INFO,DBG_INFO_PRINT," before TASK break \n");
+                    break;
+                }
+                s2 = tmp_buf;
+                field = 0;
+                while(field < MAX_NX_FIELD) {
+                    chr_ptr = strsep(&s2, ":");
+
+                    if((s2 == NULL) && (field != 4)) {
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"\n All the fields of the task %d"
+                        "should be specified ",task);
+                        exit(1);
+                }
+
+
+                switch(field) {
+                    case 0: /*In this field we expect only nx_mem_oper name */
+                        if( strcmp(chr_ptr,"CDC-CRC") == 0){
+                            r.nx_task[task].nx_operation = CDC_CRC;
+                        }else
+                        if( strcmp(chr_ptr,"CDC") == 0){
+                            r.nx_task[task].nx_operation = CDC;
+                        }else
+                        if( strcmp(chr_ptr,"BYPASS") == 0){
+                            r.nx_task[task].nx_operation = BYPASS;
+                        }else
+                        if( strcmp(chr_ptr,"C-CRC") == 0){
+                            r.nx_task[task].nx_operation = C_CRC;
+                        }else
+                        if( strcmp(chr_ptr,"C-ONLY") == 0){
+                            r.nx_task[task].nx_operation = C_ONLY;
+                        }else {
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"specify proper nx_mem ope"
+                            "ration chr_ptr = %s\n",chr_ptr);
+                            exit(1);
+                        }
+                    break;
+
+                    case 1: /* In this field we look for percentage of threads/chip */
+                        valf = atof(chr_ptr);
+                        if( valf >= 0 && valf <= 100){
+                            r.nx_task[task].thread_percent = valf;
+                        }
+                        else {
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"specify proper thread"
+                            "percent  thread_percent = %d \t task = %d \t field = %d \t"
+                            " line = %s \n",valf,task,field,s);
+                            exit(1);
+                        }
+                    break;
+
+                    case 2: /* This field is for min_buf */
+                        val = atoi(chr_ptr);
+                        if( val > 0 ){
+                            r.nx_task[task].nx_min_buf_size = (unsigned int) val;
+                        }
+                        else {
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"specify proper min_buf_size = %s \t  task = %d \t field = %d \t line = %s \n",
+                            chr_ptr,task,field,s);
+                            exit(1);
+                        }
+                    break;
+                    case 3:  /* This field is for max_buf_size */
+                        val = atoi(chr_ptr);
+                        if( val >= r.nx_task[task].nx_min_buf_size){
+                            r.nx_task[task].nx_max_buf_size = (unsigned int) val;
+                        }
+                        else {
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"specify proper "
+                            "max_buf_size = %s \t task = %d \t field = %d \t line = %s \n"
+                            "max_buf_size should be >= min_buf_size",
+                            chr_ptr,task,field,s);
+                            exit(1);
+                        }
+                    break;
+
+                    case 4:
+                        /* We are here means reached the last field which is chip number */
+                        if(strcmp(chr_ptr,"*") == 0){
+                            r.nx_task[task].chip = -1;
+                            break;
+                        }
+
+                        val = atoi(chr_ptr);
+                        if( val >= 0 && val < MAX_P7_CHIP ){
+                            r.nx_task[task].chip = val;
+                        }
+                        else {
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"specify proper "
+                            "chip = %s \t task = %d \t field = %d \t line = %s \n",
+                            chr_ptr,task,field,s);
+                            exit(1);
+                        }
+                    break;
+
+                    default:
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"specify proper "
+                        "values for line  = %s \t task = %d \t field = %d \t line = %s \n",
+                        chr_ptr,task,field,s);
+                         exit(1);
+
+                    } /* END of switch */
+
+                field++;
+                } /* END of field */
+
+            task++;
+            r.number_of_nx_task = task; /*saving number of tasks */
+            } /* END of while i < 20 */
+        /* This is a DEBUG TEST LOOP */
+        int d;
+        i = task;
+        for(task = 0; task < i; task ++){
+            d = task;
+            displaym(HTX_HE_INFO,DBG_INFO_PRINT,"r.nx_task[%d].nx_operation = %d \t"
+            "  r.nx_task[%d].thread_percent = %f \t r.nx_task[%d].nx_min_buf_size = %d \n"
+            "r.nx_task[%d].nx_max_buf_size = %d \t \t"
+            " r.nx_task[%d].chip = %d \n\n",task,r.nx_task[d].nx_operation,task,r.nx_task[d].thread_percent, \
+            task,r.nx_task[d].nx_min_buf_size,task,r.nx_task[d].nx_max_buf_size,task,
+            r.nx_task[d].chip );
+
+        }
+
+        }
+        else if ((strcmp(keywd,"CORSA_PERFORMANCE")) == 0)
+        {
+            sscanf(s,"%*s %s",r.corsa_performance);
+            if ((strcmp(r.corsa_performance,"NO")) == 0) {
+                r.corsa_perf_flag = 0;
+            }
+            else {
+                r.corsa_perf_flag = 1;
+            }
+        }
+#endif
+        else if ((strcmp(keywd,"STRIDE_SZ"))== 0)
+        {
+            sscanf(s,"%*s %d",&r.stride_sz);
+            if (r.stride_sz > MAX_STRIDE_SZ) {
+                displaym(HTX_HE_INFO, DBG_MUST_PRINT, "Stride size (%d) is greater than MAX_STRIDE_SZ(%d).\n"
+                                                      "Seeting it to MAX_STRIDE_SZ.\n",
+                                                      r.stride_sz, MAX_STRIDE_SZ);
+                r.stride_sz = MAX_STRIDE_SZ;
+            }
+        }
+
+        else if ((strcmp(keywd,"PERCENT_HW_THREADS"))== 0)
+        {
+             sscanf(s,"%*s %d",&r.percent_hw_threads);
+        }
+        else if ((strcmp(keywd,"TLBIE_TEST_CASE"))==0){
+            sscanf(s,"%*s %s",r.tlbie_test_case);
+        }
+        else if ((strcmp(keywd,"CPU_FILTER"))==0){
+
+            char *tmp_str;
+            int i = 0;
+            tmp_str=strtok_r(s," \n",ptr);
+            while (tmp_str != NULL && i <= MAX_FILTERS) {
+                tmp_str=strtok_r(NULL," \n",ptr);
+                if (tmp_str == NULL ) {
+                    break;
+                }
+                strcpy(r.cpu_filter_str[i],tmp_str);
+                debug(HTX_HE_INFO,DBG_INFO_PRINT,"[%d]cpu_filter = %s\n",i,r.cpu_filter_str[i]);
+                i++;
+            }   
+            if (tmp_str) {
+                 displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:line# %s (more than "
+                    "%d filters cannot be specified in a single rule\n",__LINE__,__FUNCTION__,s,MAX_FILTERS);
+            }
+            if ( i ) {
+                 r.num_cpu_filters = i;
+            }
+            else {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:line#%d %s (pattern not specified properly )\n",__LINE__,__FUNCTION__,*line,s);
+            }         
+        }
+        else if ((strcmp(keywd,"MEM_FILTER"))==0){
+
+            char *tmp_str;
+            int i = 0;
+            tmp_str=strtok_r(s," \n",ptr);
+            while (tmp_str != NULL && i <= MAX_FILTERS) {
+                tmp_str=strtok_r(NULL," \n",ptr);
+                if (tmp_str == NULL ) {
+                    break;
+                }
+                strcpy(r.mem_filter_str[i],tmp_str);
+                debug(HTX_HE_INFO,DBG_INFO_PRINT,"[%d]mem_filter = %s\n",i,r.mem_filter_str[i]);
+                i++;
+            }   
+            if (tmp_str) {
+                 displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:line# %s (more than "
+                    "%d filters cannot be specified in a single rule\n",__LINE__,__FUNCTION__,s,MAX_FILTERS);
+            }
+            if ( i ) {
+                 r.num_mem_filters = i;
+            }
+            else {
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:line#%d %s (pattern not specified properly )\n",__LINE__,__FUNCTION__,*line,s);
+            }         
+        }
+        else
+        {
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:line# %d keywd = %s "
+                    "(invalid)\n",__LINE__,__FUNCTION__,*line,keywd);
+            exit(1);
+        }
+    } /* end while */
+
+    *line = *line + 1;
+    if (keywd_count > 0)
+    {
+        if ((strcmp(r.rule_id,"")) == 0)
+        {
+             displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT, "[%d]%s:line# %d rule_id not"
+                     " specified \n",__LINE__,__FUNCTION__,first_line);
+             exit(1);
+        }
+         else rc=0;
+    }
+    else rc=EOF;
+
+    if (rc != EOF ) {
+
+		if(((g_data.gstanza.global_disable_filters == 0) || (g_data.sys_details.unbalanced_sys_config == 0)) && (g_data.sys_details.shared_proc_mode != 1)){
+            g_data.gstanza.global_disable_filters = 0;
+			/* calling cpu/mem  filter parsing modules*/
+			rc = parse_cpu_filter(r.cpu_filter_str);
+			if(rc != SUCCESS){
+				exit(1);
+			}
+			rc = parse_mem_filter(r.mem_filter_str);
+			if(rc != SUCCESS){
+				exit(1);
+			}
+		}
+		/* Doing a MEMCOPY .. instead of individual copy*/
+		memcpy(g_data.stanza_ptr,&r,sizeof(r));
+
+		displaym(HTX_HE_INFO,DBG_INFO_PRINT,"+All the keywords are read "
+				"sucessfully\n");
+    }
+
+    return(rc);
+}
+
+/****************************************************************
+*Reads rule file and updates rule_info structre for evry stanza *
+*function will return without parcing rule file,If there is no  *
+*change in rule file											*
+****************************************************************/
+int read_rules(void)
+{
+    struct stat fstat;
+    int i =0;
+    int line_number=0;
+
+    if ( -1 ==  stat (g_data.rules_file_name, &fstat)) {
+        displaym(HTX_HE_INFO,DBG_MUST_PRINT," [%d]%s: Error occoured while "
+                "getting the rules file stats for file %s: errno %d: %s \n",__LINE__,__FUNCTION__,g_data.rules_file_name,errno,strerror(errno));
+    }
+    else {
+        if (g_data.rf_last_mod_time != 0) {
+            if (g_data.rf_last_mod_time == fstat.st_mtime) {
+                displaym(HTX_HE_INFO,DBG_INFO_PRINT," No changes in the rules "
+                        "file stanza so skipping the read again \n");
+                return(0);
+            }
+        }
+        if (g_data.rf_last_mod_time) {
+            free_pattern_buffers();
+        }
+        g_data.rf_last_mod_time = fstat.st_mtime;
+    } /* else ends */
+    if ( (g_data.rf_ptr= fopen(g_data.rules_file_name,"r")) == NULL) {
+        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:The rules file name parameter %s to the hxemem64 binary is incorrect,fopen(),(%d)%s\n",
+			__LINE__,__FUNCTION__,g_data.rules_file_name,errno,strerror(errno));
+        return(-1);
+    }
+
+    i = 0;
+    /* Initialize global rule parameters here with default values*/
+    g_data.gstanza.global_alloc_mem_percent= DEFAULT_MEM_ALOC_PERCENT;
+	g_data.gstanza.global_mem_4k_use_percent = 50;
+	g_data.gstanza.global_mem_64k_use_percent = 50;
+	g_data.gstanza.global_alloc_mem_size= -1;
+	g_data.gstanza.global_startup_delay   = DEFAULT_DELAY; 	
+	g_data.gstanza.global_disable_filters = 1;
+    g_data.gstanza.global_alloc_huge_page = 1;
+	g_data.gstanza.global_num_threads = -1;
+    if(!g_data.standalone) {
+        g_data.gstanza.global_debug_level = 0;
+    }
+    g_data.gstanza.global_disable_cpu_bind = 0;
+    g_data.gstanza.global_alloc_segment_size = -1;
+
+    g_data.stanza_ptr=&g_data.stanza[0];
+    while ( (get_rule(&line_number,g_data.rf_ptr)) != EOF ) {
+        g_data.stanza_ptr++;
+        i++;
+        if ( i == MAX_STANZAS-2 ) {
+            displaym(HTX_HE_INFO,DBG_MUST_PRINT,"[%d]%s:The number of stanzas %d in rule file %s is more than expected (%d)) \n",
+				__LINE__,__FUNCTION__,i,g_data.rules_file_name,MAX_STANZAS);
+        }
+    }
+
+    strcpy(g_data.stanza_ptr->rule_id,"NONE");
+
+    g_data.stanza_ptr=&g_data.stanza[0];
+    i = 0;
+    while( strcmp(g_data.stanza_ptr->rule_id,"NONE") != 0)
+    {
+        int pati,patj;
+        i++;
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"stanza number #%d,\nrule_id=%s\n",i,g_data.stanza_ptr->rule_id);
+        for (pati=0; pati<g_data.stanza_ptr->num_patterns; pati++) {
+            debug(HTX_HE_INFO,DBG_INFO_PRINT,"pattern name = %s\n "
+                    "pattern_size =%d\npattern =0x",g_data.stanza_ptr->pattern_name[pati],\
+                    g_data.stanza_ptr->pattern_size[pati]);
+            for (patj=0; patj<r.pattern_size[pati]; patj++) {
+                debug(HTX_HE_INFO,DBG_INFO_PRINT,"%0x",r.pattern[pati][patj]);
+            }
+            debug(HTX_HE_INFO,DBG_INFO_PRINT,"\n");
+        }
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"pres_stanza->pattern_id=%s\n",g_data.stanza_ptr->pattern_id);
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"pres_stanza->oper=%s\n",g_data.stanza_ptr->oper);
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"pres_stanza->compare=%s\n",g_data.stanza_ptr->compare);
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"pres_stanza->crash_on_mis=%s\n",g_data.stanza_ptr->crash_on_mis);
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"pres_stanza->turn_attn_on=%s\n",g_data.stanza_ptr->turn_attn_on);
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"pres_stanza->num_oper=%d\n",g_data.stanza_ptr->num_oper);
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"pres_stanza->num_writes=%d\n",g_data.stanza_ptr->num_writes);
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"pres_stanza->num_reads=%d\n",g_data.stanza_ptr->num_reads);
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"pres_stanza->num_compares=%d\n",g_data.stanza_ptr->num_compares);
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"pres_stanza->width=%d\n",g_data.stanza_ptr->width);
+        debug(HTX_HE_INFO,DBG_INFO_PRINT,"pres_stanza->debug_level=%d\n",g_data.stanza_ptr->debug_level);
+        g_data.stanza_ptr++;
+    } /* while (strcmp(.... ENDS */
+
+	fclose(g_data.rf_ptr);
+     return(0);
+} /* read_rules function ends */
+

--- a/bin/hxemem64/parse_filters.c
+++ b/bin/hxemem64/parse_filters.c
@@ -1,0 +1,1066 @@
+/* IBM_PROLOG_BEGIN_TAG */
+/*
+ * Copyright 2003,2016 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "nest_framework.h"
+/*#define debug displaym*/
+extern char page_size_name[MAX_PAGE_SIZES][8];
+extern struct rule_info r;
+extern struct nest_global g_data;
+int parse_mem_filter(char filter_ptr[][MAX_POSSIBLE_ENTRIES]){
+    int i,j,filt_idx,num_nodes = 0,num_chips = 0;
+    unsigned long node_num,chip_num,chips_in_this_node,nodes_in_this_sys;
+    char* chr_ptr[r.num_mem_filters][16],*end_ptr;
+    char *ptr[16],*tmp,*tmp_str=NULL,c[8],tmp_filter_str[MAX_POSSIBLE_ENTRIES];
+    struct sys_info* sysptr = &g_data.sys_details;
+    char msg[4096],msg_temp[2048];
+
+
+    for(int node = 0; node < MAX_NODES;node++ ){
+        for(int chip = 0; chip < MAX_CHIPS_PER_NODE;chip++){
+            for(int core = 0; core < MAX_CORES_PER_CHIP;core++){
+                for(int lcpu=0;lcpu < MAX_CPUS_PER_CORE;lcpu++){
+                   r.filter.mf.node[node].chip[chip].core[core].lprocs[lcpu]=-1;
+                   r.filter.mf.node[node].chip[chip].core[core].num_procs = 0;
+                }
+                r.filter.mf.node[node].chip[chip].core[core].core_num=-1;
+            }
+            r.filter.mf.node[node].chip[chip].num_cores=0;
+            r.filter.mf.node[node].chip[chip].chip_num =-1;
+            for(int p=0;p<MAX_PAGE_SIZES;p++){
+                r.filter.mf.node[node].chip[chip].mem_details.pdata[p].page_wise_usage_mem=0;
+                r.filter.mf.node[node].chip[chip].mem_details.pdata[p].page_wise_usage_mpercent=0;
+                r.filter.mf.node[node].chip[chip].mem_details.pdata[p].page_wise_usage_npages=0;
+            }
+        }
+        r.filter.mf.node[node].num_chips=0;
+        r.filter.mf.node[node].node_num=-1;
+    }r.filter.mf.num_nodes =0;
+
+    sprintf(msg,"\n====================================================\n"
+        "Memory filter details\n====================================================\n");
+    for(filt_idx = 0; filt_idx < r.num_mem_filters; filt_idx++){
+        
+        sprintf(msg_temp,"mem filter[%d]=%s\n",filt_idx,filter_ptr[filt_idx]);
+        strcat(msg,msg_temp);
+        i = 0,j=0,node_num=0,num_nodes=0;
+        strcpy(tmp_filter_str,filter_ptr[filt_idx]);
+        if((strchr(tmp_filter_str,'N') == NULL)||(strchr(tmp_filter_str,'P')== NULL)){
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+            "for mem_filer:%s,filter num:%d,cpu filter must conatin both 'N' & 'P'\n",
+            __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx);
+            return FAILURE;
+        }
+
+        if ((chr_ptr[filt_idx][i] = strtok(tmp_filter_str, "NP")) != NULL) {
+            i++;
+            while ((chr_ptr[filt_idx][i] = strtok(NULL, "NP")) != NULL) {
+                i++;
+            }
+
+        }else {
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s for mem filter :%s,"
+                    "filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx);
+                return (FAILURE);
+        }
+        nodes_in_this_sys = get_num_of_nodes_in_sys();
+        if (chr_ptr[filt_idx][0][0] == '*'){
+            num_nodes = nodes_in_this_sys;
+            r.filter.mf.num_nodes = nodes_in_this_sys;
+            for(int n=0;n<num_nodes;n++){
+                if(r.filter.mf.node[n].node_num == -1){
+                     r.filter.mf.node[n].node_num=n;
+                }
+            }
+        }
+        else if (strchr(chr_ptr[filt_idx][0],'[') != NULL) { /* indicates a range of nodes is given in filter */
+            if((tmp_str = (char*)malloc(strlen(chr_ptr[filt_idx][0])+2)) == NULL){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:malloc failed with errno %d(%s) for size = %d\n"
+                        ,__LINE__,__FUNCTION__,errno,strerror(errno),(strlen(chr_ptr[filt_idx][0])+2));
+                return FAILURE;
+            }
+            strcpy(tmp_str,chr_ptr[filt_idx][0]);
+            if((ptr[j++] = strtok(tmp_str,"[],")) == NULL){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s for mem filter :%s,"
+                    "filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx);
+                return (FAILURE);
+            }
+
+            while ((ptr[j]=strtok(NULL,",]")) != NULL ){
+                j++;
+            }
+            errno=0;
+            for(int k = 0;k<j;k++){
+                if ((tmp = strchr(ptr[k],'%')) != NULL) { /* indicates a percentage of nodes is given in filter */
+                    num_nodes = (nodes_in_this_sys * (float)((atoi(tmp+1))/100.0));
+                    if((num_nodes< 0) ||  (num_nodes> nodes_in_this_sys)){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule  %s, rule file:%s for mem_filer:%s,"
+                            "filter num:%d, node percentage as %d%(num_nodes=%d)\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                             filter_ptr[filt_idx],filt_idx,atoi(tmp+1),num_nodes);
+                        return (FAILURE);
+                    }
+                    if(num_nodes== 0)num_nodes= 1;
+                    for(int n =0;n<num_nodes;n++){
+                        if(r.filter.mf.node[n].node_num == -1){
+                             r.filter.mf.node[n].node_num = n;
+                        }
+                    }
+                }else if (strchr(ptr[k],'-') == NULL){
+                    node_num = strtol(ptr[k],&end_ptr,10);
+                    if(node_num >= nodes_in_this_sys ||  errno != 0 || end_ptr == ptr[k]){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s  for mem_filer:%s,"
+                            "filter num:%d, node filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                            filter_ptr[filt_idx], filt_idx,node_num,nodes_in_this_sys);
+                        return (FAILURE);
+                    }
+                    num_nodes++;
+                    if(r.filter.mf.node[node_num].node_num == -1){
+                        r.filter.mf.node[node_num].node_num = node_num;
+                    }
+                }
+
+                else {
+                    strcpy(c,ptr[k]);
+                    if((tmp=strtok(c,"-")) == NULL){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule  rule %s, rule file:%s " 
+                            "for mem_filer:%s,filter num:%d\n",__LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                            filter_ptr[filt_idx],filt_idx);
+                        return (FAILURE);
+
+                    }
+                    if((tmp=strtok(NULL,"-")) == NULL){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                           "for mem_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                            filter_ptr[filt_idx],filt_idx);
+                        return (FAILURE);
+
+                    }
+
+                    errno = 0;
+                    node_num = strtol(tmp,&end_ptr,10);
+                    if(r.filter.mf.node[node_num].node_num == -1){
+                        r.filter.mf.node[node_num].node_num = node_num;
+                    }
+                    if(node_num >= nodes_in_this_sys ||  errno != 0 || end_ptr == ptr[k]){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                            "for mem_filer:%s,filter num:%d, node filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                            filter_ptr[filt_idx],filt_idx,node_num,nodes_in_this_sys);
+                         return (FAILURE);
+                    }
+                    errno = 0;
+                    for(int n=strtol(&ptr[k][0],&end_ptr,10);n <= node_num;n++){
+                        if(n >= nodes_in_this_sys || errno != 0 || end_ptr == &ptr[k][0]){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                "for mem_filer:%s,filter num:%d, node filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                                filter_ptr[filt_idx],filt_idx,node_num,nodes_in_this_sys);
+                            return (FAILURE);
+                        }
+                        if(r.filter.mf.node[n].node_num == -1){
+                        r.filter.mf.node[n].node_num = n;
+                    }
+                    num_nodes++;
+                }
+            }
+        }
+        free(tmp_str);
+        }else if ((tmp = strchr(chr_ptr[filt_idx][0],'%')) != NULL) { /* indicates a percentage of nodes is given in filter */
+            num_nodes = (nodes_in_this_sys * (float)((atoi(tmp+1))/100.0));
+            if((num_nodes < 0) ||  (num_nodes > nodes_in_this_sys)){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                    "for mem_filer:%s,filter num:%d, node percentage as %d%(num_nodes=%d)\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                        filter_ptr[filt_idx],filt_idx,atoi(tmp+1),num_nodes);
+                     return (FAILURE);
+            }
+            if(num_nodes == 0)num_nodes=1;
+            for(int n=0;(n<num_nodes);n++){
+                if(r.filter.mf.node[n].node_num == -1)
+                r.filter.mf.node[n].node_num=n;
+            }
+        }else {
+            errno = 0;
+            node_num = strtol(chr_ptr[filt_idx][0],&end_ptr,10);
+            if(node_num >= nodes_in_this_sys ||  errno != 0 || end_ptr == chr_ptr[filt_idx][0]){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                    "for mem_filter:%s,filter num:%d, node filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                    filter_ptr[filt_idx],filt_idx,node_num,nodes_in_this_sys);
+                return (FAILURE);
+            }
+            num_nodes = 1;
+            if(r.filter.mf.node[node_num].node_num == -1){
+                r.filter.mf.node[node_num].node_num = node_num;
+            }
+        }
+
+        sprintf(msg_temp,"\nnum_nodes=%d:\t",num_nodes);
+        strcat(msg,msg_temp);
+        for(int k=0;k<MAX_NODES;k++){
+            if(r.filter.mf.node[k].node_num == -1) continue;
+            sprintf(msg_temp," %d \t",r.filter.mf.node[k].node_num);
+            strcat(msg,msg_temp);
+        }
+        struct chip_info *chip_ptr = NULL;
+        r.filter.mf.num_nodes = num_nodes;
+
+        for (int n = 0; n < MAX_NODES; n++) {
+			int temp_chips[MAX_CHIPS_PER_NODE]={[0 ... (MAX_CHIPS_PER_NODE- 1)] = -1};
+            num_chips = 0;chip_num=0;
+            chips_in_this_node= get_num_of_chips_in_node(n);
+            chip_ptr = &r.filter.mf.node[n].chip[0];
+            if((r.filter.mf.node[n].node_num == -1) || (r.filter.mf.node[n].num_chips == chips_in_this_node)){
+                continue;
+            }
+            if (strchr(chr_ptr[filt_idx][1],'[') != NULL) {
+
+                if((tmp_str = (char*)malloc(strlen(chr_ptr[filt_idx][1])+2)) == NULL){
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:malloc failed with errno %d(%s) for size = %d\n"
+                        ,__LINE__,__FUNCTION__,errno,strerror(errno),(strlen(chr_ptr[filt_idx][1])+2));
+                    return FAILURE;
+                }
+                j=0;
+                strcpy(tmp_str,chr_ptr[filt_idx][1]);
+                debug(HTX_HE_INFO,DBG_MUST_PRINT,"tmp_str = %s\n",tmp_str);
+                if((ptr[j++] = strtok(tmp_str,"[],")) == NULL){
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                    "for mem_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                    filter_ptr[filt_idx],filt_idx);
+                    return (FAILURE);
+                }
+                debug(HTX_HE_INFO,DBG_MUST_PRINT,"ptr[0]=%s\n",ptr[0]);
+                if (chr_ptr[filt_idx][1][0]  == '*'){
+                        num_chips = chips_in_this_node;
+                        for(int chp = 0;(chp<chips_in_this_node);chp++){
+                            if(chip_ptr[chp].chip_num == -1){
+                                chip_ptr[chp].chip_num = chp;
+								temp_chips[chp] = chp;
+                            }
+                        }    
+                }else{
+                    errno = 0;     
+                    chip_num = strtol(ptr[0],&end_ptr,10);
+                    if(chip_num >= chips_in_this_node ||  errno != 0 || end_ptr == ptr[0]){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule rule %s, rule file:%s "
+                        "for [%d]mem_filer:%s,chip field as %s\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                        filt_idx,filter_ptr[filt_idx],ptr[0]);
+                        return (FAILURE);
+                        
+                    }           
+                    if(chip_ptr[chip_num].chip_num == -1){
+                        chip_ptr[chip_num].chip_num = chip_num;
+						temp_chips[chip_num] = chip_num;
+                        num_chips++;
+                    }
+                }
+                while ((ptr[j]=strtok(NULL,",]")) != NULL ){
+                    debug(HTX_HE_INFO,DBG_MUST_PRINT,"ptr[%d]=%s\n",j,ptr[j]);
+                    j++;
+                }
+                for(int k = 0,l=1;l<j;k++,l++){/*l =1,because first token immidiately after "P" in mem_filter is  always chip number,jumping to page details*/
+                
+                    char *page_size_tok[6],*page_value_tok[6],tmp_page_value[8];
+                    int page_index;
+                    unsigned long num_value;
+                    if(((page_size_tok[k] = strtok(ptr[l],"_")) == NULL) ){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule  %s, rule file:%s "
+                            "for [%d]mem_filer:%s,page filed as %s\n",__LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                            filt_idx,filter_ptr[filt_idx],ptr[k]);
+                            return (FAILURE);
+                    }        
+                    debug(HTX_HE_INFO,DBG_MUST_PRINT,"page_size_tok[%d]=%s\n",k,page_size_tok[k]);
+                    if((strcmp(page_size_tok[k],"4K") == 0) || (strcmp(page_size_tok[k],"4k") == 0)){
+                       page_index = PAGE_INDEX_4K; 
+                    }else if((strcmp(page_size_tok[k],"64K") == 0) || (strcmp(page_size_tok[k],"64k") == 0)){
+                        page_index = PAGE_INDEX_64K;
+                    }else if((strcmp(page_size_tok[k],"2M") == 0) || (strcmp(page_size_tok[k],"2m") == 0)){
+                        page_index = PAGE_INDEX_2M;
+                    }else if((strcmp(page_size_tok[k],"16M") == 0) || (strcmp(page_size_tok[k],"16m") == 0)){
+                        page_index = PAGE_INDEX_16M;
+                    }else if((strcmp(page_size_tok[k],"16G") == 0) || (strcmp(page_size_tok[k],"16g") == 0)){
+                        page_index = PAGE_INDEX_16G;
+                    }else{
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                        "for [%d]mem_filer:%s,page filed as %s\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                        filt_idx,filter_ptr[filt_idx],page_size_tok[k]);
+                        return (FAILURE);
+                    }
+
+                    if((page_value_tok[k] = strtok(NULL,"_")) == NULL) {
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                        "for [%d]mem_filer:%s,page filed as %s\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                        filt_idx,filter_ptr[filt_idx],ptr[l]);
+                        return (FAILURE);
+                    }
+                    if(!(sysptr->memory_details.pdata[page_index].supported)){
+                        displaym(HTX_HE_INFO,DBG_IMP_PRINT,"\npage size(%s) mentioned in filter [%d]mem_filer:%s  does not support on this OS/Ssytem,Continuing with next page size\n",
+                            page_size_name[page_index],filt_idx,filter_ptr[filt_idx]);
+                        continue;
+                    }
+                    debug(HTX_HE_INFO,DBG_MUST_PRINT,"page_value_tok[%d]=%s\n",k,page_value_tok[k]);
+                    strcpy(tmp_page_value,page_value_tok[k]);
+                    errno = 0;     
+                    if(strstr(tmp_page_value,"%")){
+                        page_value_tok[k] = strtok(tmp_page_value,"%");
+                        num_value = strtol(page_value_tok[k],&end_ptr,10);
+						for(int chip_n =0; chip_n < MAX_CHIPS_PER_NODE; chip_n++){
+							if((temp_chips[chip_n]  == -1) || (chip_ptr[chip_n].mem_details.pdata[page_index].page_wise_usage_mem != 0)){
+								continue;	
+							}
+                        	if((num_value  <= 0) || (num_value  > 100) ||  (errno != 0) || (end_ptr == page_value_tok[k])) {
+                            	displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                	"for [%d]mem_filer:%s,page percetage filed as(%s):%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                                	filt_idx,filter_ptr[filt_idx],page_size_name[page_index],num_value);
+                            	return (FAILURE);
+                        	}
+                    
+
+                        	chip_ptr[chip_n].mem_details.pdata[page_index].page_wise_usage_mpercent = num_value; 
+                            int temp_mem_percent = g_data.gstanza.global_alloc_mem_percent;
+                            if(page_index < PAGE_INDEX_2M){
+                                if(g_data.gstanza.global_alloc_mem_size > 0 && g_data.gstanza.global_alloc_mem_size < sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free){
+                                    temp_mem_percent = (g_data.gstanza.global_alloc_mem_size * 100.0) / (sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free);
+                                }
+                        	    chip_ptr[chip_n].mem_details.pdata[page_index].page_wise_usage_mem = (num_value/100.0) * 
+                                    (sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free) * (temp_mem_percent/100.0);                         
+                            }else{
+                                chip_ptr[chip_n].mem_details.pdata[page_index].page_wise_usage_mem = (num_value/100.0) *
+                                    (sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free);
+                            }
+						}
+                    }else if(strstr(tmp_page_value,"MB")){
+                        page_value_tok[k] = strtok(tmp_page_value,"MB");
+                        errno = 0;
+                        num_value = strtol(page_value_tok[k],&end_ptr,10);
+						for(int chip_n =0; chip_n < MAX_CHIPS_PER_NODE; chip_n++){
+							if((temp_chips[chip_n]  == -1) || (chip_ptr[chip_n].mem_details.pdata[page_index].page_wise_usage_mem != 0 ||
+                                sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free == 0 )){
+								continue;	
+							}
+							if(((num_value * MB) <= 0) || ((num_value * MB) >= sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free)
+								 || (errno != 0) || (end_ptr == page_value_tok[k])){
+								displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule rule %s, rule file:%s "
+								"for [%d]mem_filer:%s,page value field as(%s):%d MB,memory abosulte value must not be <=0"
+								"  nor should exceed max limit %luMB\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+								filt_idx,filter_ptr[filt_idx],page_size_name[page_index],num_value,
+								(sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free/MB));
+								return (FAILURE);
+
+							}
+							chip_ptr[chip_n].mem_details.pdata[page_index].page_wise_usage_mem = (num_value * MB);
+						}
+                    }else if(strstr(tmp_page_value,"GB")){
+                        page_value_tok[k] = strtok(tmp_page_value,"GB");
+                        errno = 0;
+                        num_value = strtol(page_value_tok[k],&end_ptr,10);
+						for(int chip_n =0; chip_n < MAX_CHIPS_PER_NODE; chip_n++){
+							if((temp_chips[chip_n]  == -1) || (chip_ptr[chip_n].mem_details.pdata[page_index].page_wise_usage_mem != 0 ||
+                                sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free == 0 )){
+								continue;	
+							}
+							if(((num_value * GB) <= 0) || ((num_value * GB) >= sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free) ||
+								 (errno != 0) || (end_ptr == page_value_tok[k])){
+								displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+								"file for [%d]mem_filer:%s,page value field as(%s):%dGB,memory abosulte value must not be <=0"
+								"  nor should exceed max limit %luMB\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+								filt_idx,filter_ptr[filt_idx],page_size_name[page_index],num_value,
+								(sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free/MB));
+								return (FAILURE);
+
+							}
+                        	chip_ptr[chip_n].mem_details.pdata[page_index].page_wise_usage_mem = (num_value * GB);
+						}
+                    }else if(strstr(tmp_page_value,"#")){
+                        unsigned long mem_size=0;
+                        page_value_tok[k] = strtok(tmp_page_value,"#");
+                        errno = 0;
+                        num_value = strtol(page_value_tok[k],&end_ptr,10);
+						for(int chip_n =0; chip_n < MAX_CHIPS_PER_NODE; chip_n++){
+							temp_chips[chip_n] = chip_ptr[chip_n].chip_num;
+							if((temp_chips[chip_n]  == -1) || (chip_ptr[chip_n].mem_details.pdata[page_index].page_wise_usage_mem != 0 ||
+                                sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free == 0 )){
+								continue;	
+							}
+                        	mem_size  = (num_value * sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].psize);
+                        	if((mem_size <=0) || (mem_size >= sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free) || (errno != 0) || (end_ptr == page_value_tok[k])){
+                            	displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                            	"for [%d]mem_filer:%s,number of pages as (%s):%d pages, num pages  must not be <=0  "
+                            	"nor should exceed %d ,errored out for node:%d,chip:%d\n",__LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                            	filt_idx,filter_ptr[filt_idx],page_size_name[page_index],num_value,
+                            	(sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].free/sysptr->node[n].chip[chip_n].mem_details.pdata[page_index].psize),
+                                 n,chip_n);
+                            	return (FAILURE);
+
+                       	 	}	 
+                        	chip_ptr[chip_n].mem_details.pdata[page_index].page_wise_usage_mem = mem_size;
+                        	chip_ptr[chip_n].mem_details.pdata[page_index].page_wise_usage_npages = num_value;
+						}
+                    }else {
+
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                            "for [%d]mem_filer:%s,page filed as %s must be in percentage  or MB or GB or #, "
+                            "as documneted in rule file\n",__LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                            filt_idx,filter_ptr[filt_idx],tmp_page_value);
+                             return (FAILURE);
+                    }
+                    debug(HTX_HE_INFO,DBG_MUST_PRINT,"page_value_tok[%d]=%s,num_value=%d\n",k,page_value_tok[k],num_value);
+					for(int chip_n =0; chip_n < MAX_CHIPS_PER_NODE; chip_n++){
+						if(chip_ptr[chip_n].chip_num == -1)continue;	
+                    	sprintf(msg_temp,"\nmem filter node[%d]chip[%d]page[%s] page_wise_mem_to_use =%lu\n",n,chip_n,page_size_name[page_index],
+                        	r.filter.mf.node[n].chip[chip_n].mem_details.pdata[page_index].page_wise_usage_mem);
+                    	strcat(msg,msg_temp);
+					}
+                }                    
+                free(tmp_str);
+                r.filter.mf.node[n].num_chips = num_chips;
+				/*initialize chip_num=-1 so that if any next filter with different chip of same node should not consider current filter page values*/
+				for(int chip_n =0; chip_n < MAX_CHIPS_PER_NODE; chip_n++){
+					temp_chips[chip_n] = -1;
+				}
+            }else{
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                    "for [%d]mem_filer:%s,chip field as %c\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                    filt_idx,filter_ptr[filt_idx],chr_ptr[filt_idx][1][0]);
+                    return (FAILURE);
+            }
+            
+        }
+    }
+    displaym(HTX_HE_INFO,DBG_DEBUG_PRINT,"%s\n",msg);
+    return SUCCESS;
+}
+int parse_cpu_filter(char filter_ptr[][MAX_POSSIBLE_ENTRIES]){
+    int i,j,filt_idx,num_nodes = 0,num_chips = 0,num_cores=0,num_cpus=0;
+    unsigned long node_num,chip_num,core_num,cpu_num,cores_in_this_chip,chips_in_this_node,nodes_in_this_sys,cpus_in_this_core;
+    char *tmp_str=NULL,msg[8092],msg_temp[2048];
+    char* chr_ptr[r.num_cpu_filters][8],*end_ptr;
+    char *ptr[16],*tmp,c[8],tmp_filter_str[MAX_POSSIBLE_ENTRIES];
+
+
+    for(int node = 0; node < MAX_NODES;node++ ){
+        for(int chip = 0; chip < MAX_CHIPS_PER_NODE;chip++){
+            for(int core = 0; core < MAX_CORES_PER_CHIP;core++){
+                for(int lcpu=0;lcpu < MAX_CPUS_PER_CORE;lcpu++){
+                   r.filter.cf.node[node].chip[chip].core[core].lprocs[lcpu]=-1;
+                   r.filter.cf.node[node].chip[chip].core[core].num_procs = 0;
+                }
+                r.filter.cf.node[node].chip[chip].core[core].core_num=-1;
+            }
+            r.filter.cf.node[node].chip[chip].num_cores=0;
+            r.filter.cf.node[node].chip[chip].chip_num =-1;
+            
+        }
+        r.filter.cf.node[node].num_chips=0;
+        r.filter.cf.node[node].node_num=-1;
+    }r.filter.cf.num_nodes =0;
+
+#if 0
+    for(int row = 0;row < MAX_FILTERS;row++){
+        for(int col=0;col<MAX_NODES;col++){
+            nodes[row][col] = -1;
+        }
+    }
+#endif
+    sprintf(msg,"CPU Filter Details:");
+    for(filt_idx = 0; filt_idx < r.num_cpu_filters; filt_idx++){
+        sprintf(msg_temp,"\n=======================================================================\n"
+            "cpu filter[%d]=%s\n",filt_idx,filter_ptr[filt_idx]);
+        strcat(msg,msg_temp);
+        i = 0,j=0,node_num=0,num_nodes=0;
+        strcpy(tmp_filter_str,filter_ptr[filt_idx]);
+        if((strchr(tmp_filter_str,'N') == NULL)||(strchr(tmp_filter_str,'P')== NULL)||(strchr(tmp_filter_str,'C')== NULL)||(strchr(tmp_filter_str,'T')== NULL)){
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+            "for cpu_filer:%s,filter num:%d,cpu filter must conatin all 'N','P','C' and 'T'\n", 
+            __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx);
+            return FAILURE;
+        }
+        if ((chr_ptr[filt_idx][i] = strtok(tmp_filter_str, "NPCT")) != NULL) {
+            i++;
+            while ((chr_ptr[filt_idx][i] = strtok(NULL, "NPCT")) != NULL) {
+                i++;    
+            }
+        }else {
+            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                "for cpu_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                filter_ptr[filt_idx],filt_idx);
+            return (FAILURE);
+        }
+        nodes_in_this_sys = get_num_of_nodes_in_sys();
+        if (chr_ptr[filt_idx][0][0] == '*'){
+            num_nodes = nodes_in_this_sys;
+            r.filter.cf.num_nodes = nodes_in_this_sys;
+            for(int n=0;n<num_nodes;n++){
+                if(r.filter.cf.node[n].node_num == -1){
+                     r.filter.cf.node[n].node_num=n;
+                }
+            }
+        }
+        else if (strchr(chr_ptr[filt_idx][0],'[') != NULL) { /* indicates a range of nodes is given in filter */
+            if((tmp_str = (char*)malloc(strlen(chr_ptr[filt_idx][0])+2)) == NULL){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:malloc failed with errno %d(%s) for size = %d\n"
+                        ,__LINE__,__FUNCTION__,errno,strerror(errno),(strlen(chr_ptr[filt_idx][0])+2));
+                return FAILURE;
+            }
+            strcpy(tmp_str,chr_ptr[filt_idx][0]);
+            if((ptr[j++] = strtok(tmp_str,"[],")) == NULL){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                    "for cpu_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                    filter_ptr[filt_idx],filt_idx);
+                return (FAILURE);
+            }
+            
+            while ((ptr[j]=strtok(NULL,",]")) != NULL ){
+                j++;
+            }
+            errno=0;
+            for(int k = 0;k<j;k++){
+                if ((tmp = strchr(ptr[k],'%')) != NULL) { /* indicates a percentage of nodes is given in filter */
+                    num_nodes = (nodes_in_this_sys * (float)((atoi(tmp+1))/100.0));
+                    if((num_nodes< 0) ||  (num_nodes> nodes_in_this_sys)){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                            "for cpu_filer:%s,filter num:%d, node percentage as %d%(num_nodes=%d)\n", __LINE__,__FUNCTION__,
+                            r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,atoi(tmp+1),num_nodes);
+                        return (FAILURE);
+                    }
+                    if(num_nodes== 0)num_nodes= 1;
+                    for(int n =0;n<num_nodes;n++){
+                        if(r.filter.cf.node[n].node_num == -1){
+                             r.filter.cf.node[n].node_num = n;
+                        }
+                    }
+                }else if (strchr(ptr[k],'-') == NULL){
+                    node_num = strtol(ptr[k],&end_ptr,10);
+                    if(node_num >= nodes_in_this_sys ||  errno != 0 || end_ptr == ptr[k]){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                            "for cpu_filer:%s,filter num:%d, node filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,
+                            r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,node_num,nodes_in_this_sys);
+                        return (FAILURE);
+                    }
+                    num_nodes++;
+                    if(r.filter.cf.node[node_num].node_num == -1){
+                        r.filter.cf.node[node_num].node_num = node_num;
+                    }
+                }
+                    
+                else { 
+                    strcpy(c,ptr[k]);
+                    if((tmp=strtok(c,"-")) == NULL){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                            "for cpu_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                            filter_ptr[filt_idx],filt_idx);
+                        return (FAILURE);
+
+                    }
+                    if((tmp=strtok(NULL,"-")) == NULL){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                            "for cpu_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                            filter_ptr[filt_idx],filt_idx);
+                        return (FAILURE);
+
+                    }
+                    errno = 0;
+                    node_num = strtol(tmp,&end_ptr,10);
+                    if(r.filter.cf.node[node_num].node_num == -1){
+                        r.filter.cf.node[node_num].node_num = node_num;
+                    }
+                    if(node_num >= nodes_in_this_sys ||  errno != 0 || end_ptr == ptr[k]){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                            "for cpu_filer:%s,filter num:%d, node filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                            filter_ptr[filt_idx],filt_idx,node_num,nodes_in_this_sys);
+                         return (FAILURE);
+                    }
+                    errno = 0;
+                    for(int n=strtol(&ptr[k][0],&end_ptr,10);n <= node_num;n++){
+                        if(n >= nodes_in_this_sys || errno != 0 || end_ptr == &ptr[k][0]){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                "for cpu_filer:%s,filter num:%d, node filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                                filter_ptr[filt_idx],filt_idx,node_num,nodes_in_this_sys);
+                            return (FAILURE);
+                        }
+                        if(r.filter.cf.node[n].node_num == -1){
+                            r.filter.cf.node[n].node_num = n;
+                        }
+                        num_nodes++;
+                    }
+                }
+            }
+            free(tmp_str);
+        }else if ((tmp = strchr(chr_ptr[filt_idx][0],'%')) != NULL) { /* indicates a percentage of nodes is given in filter */
+            num_nodes = (nodes_in_this_sys * (float)((atoi(tmp+1))/100.0));
+            if((num_nodes < 0) ||  (num_nodes > nodes_in_this_sys)){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                    "for cpu_filer:%s,filter num:%d, node percentage as %d%(num_nodes=%d)\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                    filter_ptr[filt_idx],filt_idx,atoi(tmp+1),num_nodes);
+                return (FAILURE);
+            }
+            if(num_nodes == 0)num_nodes=1;
+            for(int n=0;(n<num_nodes);n++){
+                if(r.filter.cf.node[n].node_num == -1)
+                r.filter.cf.node[n].node_num=n;
+            }
+        }else {
+            errno = 0;
+            node_num = strtol(chr_ptr[filt_idx][0],&end_ptr,10);
+            if(node_num >= nodes_in_this_sys ||  errno != 0 || end_ptr == chr_ptr[filt_idx][0]){
+                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                    "for cpu_filer:%s,filter num:%d, node filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                     filter_ptr[filt_idx],filt_idx,node_num,nodes_in_this_sys);
+                return (FAILURE);
+            }
+            num_nodes = 1;
+            if(r.filter.cf.node[node_num].node_num == -1){
+                r.filter.cf.node[node_num].node_num = node_num;
+            }
+        }
+
+        sprintf(msg_temp,"num_nodes=%d:\t",num_nodes);
+        strcat(msg,msg_temp);
+        for(int k=0;k<MAX_NODES;k++){
+            if(r.filter.cf.node[k].node_num == -1) continue;
+            sprintf(msg_temp," %d \t",r.filter.cf.node[k].node_num);
+            strcat(msg,msg_temp);
+        } 
+        struct chip_info *chip_ptr = NULL;
+        r.filter.cf.num_nodes = num_nodes;
+        for (int n = 0; n < MAX_NODES; n++) {
+            num_chips = 0;chip_num=0;
+            chips_in_this_node= get_num_of_chips_in_node(n);
+            chip_ptr = &r.filter.cf.node[n].chip[0];
+            if((r.filter.cf.node[n].node_num == -1) || (r.filter.cf.node[n].num_chips == chips_in_this_node)){
+                continue;
+            } 
+            if (chr_ptr[filt_idx][1][0] == '*'){
+                    num_chips = chips_in_this_node;
+                    for(int chp = 0;(chp<chips_in_this_node);chp++){
+                        if(chip_ptr[chp].chip_num == -1)
+                             chip_ptr[chp].chip_num = chp;
+                    }
+            } else if (strchr(chr_ptr[filt_idx][1],'[') != NULL) { /*indicates a range of chips is given in filter */
+        
+                if((tmp_str = (char*)malloc(strlen(chr_ptr[filt_idx][1])+2)) == NULL){
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:malloc failed with errno %d(%s) for size = %d\n"
+                            ,__LINE__,__FUNCTION__,errno,strerror(errno),(strlen(chr_ptr[filt_idx][1])+2));
+                    return FAILURE;
+                }
+                j=0;
+                strcpy(tmp_str,chr_ptr[filt_idx][1]);
+                if((ptr[j++] = strtok(tmp_str,"[],")) == NULL){
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                        "for cpu_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,
+                        r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx);
+                    return (FAILURE);
+                }
+
+                while ((ptr[j]=strtok(NULL,",]")) != NULL ){
+                    j++;
+                }
+                errno=0;
+                for(int k = 0;k<j;k++){
+                    if ((tmp = strchr(ptr[k],'%')) != NULL) { /* indicates a percentage of chips is given in filter */
+                        num_chips = (chips_in_this_node * (float)((atoi(tmp+1))/100.0));
+                        if((num_chips < 0) ||  (num_chips > chips_in_this_node)){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                "for cpu_filer:%s,filter num:%d, chip percentage as %d%(num_chips=%d)\n", __LINE__,__FUNCTION__,
+                                r.rule_id,g_data.rules_file_name, filter_ptr[filt_idx],filt_idx,atoi(tmp+1),num_chips);
+                            return (FAILURE);
+                        }
+                        if(num_chips== 0)num_chips= 1;
+                        for(int chp =0;(chp<num_chips);chp++){
+                            if(chip_ptr[chp].chip_num == -1)
+                                chip_ptr[chp].chip_num = chp;
+                        }
+                    }else if (strchr(ptr[k],'-') == NULL){
+                        chip_num = strtol(ptr[k],&end_ptr,10);
+                        if(chip_num >= chips_in_this_node ||  errno != 0 || end_ptr == ptr[k]){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                "for cpu_filer:%s,filter num:%d, chip filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,
+                                r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,chip_num,chips_in_this_node);
+                            return (FAILURE);
+                        }
+                        if(chip_ptr[chip_num].chip_num == -1){
+                            chip_ptr[chip_num].chip_num = chip_num;
+                            num_chips++;
+                        }
+                    }
+                    else {
+                        strcpy(c,ptr[k]);
+                        if((tmp=strtok(c,"-")) == NULL){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                "for cpu_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                                filter_ptr[filt_idx],filt_idx);
+                            return (FAILURE);
+
+                        }
+                        if((tmp=strtok(NULL,"-")) == NULL){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                "for cpu_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                                filter_ptr[filt_idx],filt_idx);
+                            return (FAILURE);
+
+                        }
+                        errno = 0;
+                        chip_num = strtol(tmp,&end_ptr,10);
+                        if(chip_ptr[chip_num].chip_num == -1){
+                            chip_ptr[chip_num].chip_num = chip_num;
+                        }
+                        if(chip_num >= chips_in_this_node ||  errno != 0 || end_ptr == ptr[k]){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule  %s, rule file:%s "
+                                "for cpu_filer:%s,filter num:%d, chip field as %d ( must be < %d)\n", __LINE__,__FUNCTION__,
+                                r.rule_id,g_data.rules_file_name, filter_ptr[filt_idx],filt_idx,chip_num,chips_in_this_node);
+                             return (FAILURE);
+                        }
+                        errno = 0;
+                        for(int chp=strtol(&ptr[k][0],&end_ptr,10);(chp <= chip_num);chp++){
+                            if(chp >=chips_in_this_node || errno != 0 || end_ptr == &ptr[k][0]){
+                                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                "for cpu_filer:%s,filter num:%d, chip filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,
+                                r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,chip_num,chips_in_this_node);
+                                return (FAILURE);
+                            }
+                            if(chip_ptr[chp].chip_num==-1){
+                                chip_ptr[chp].chip_num=chp;
+                            }
+                            num_chips++;
+                       
+                        }
+                    }
+                }
+                free(tmp_str);
+
+            }else if ((tmp = strchr(chr_ptr[filt_idx][1],'%')) != NULL) { /* indicates a percentage of chips is given in filter */  
+                num_chips = (chips_in_this_node * (float)((atoi(tmp+1))/100.0));
+                if((num_chips < 0) ||  (num_chips > chips_in_this_node)){
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                        "for cpu_filer:%s,filter num:%d, chip percentage as %d%(num_chips=%d)\n", __LINE__,__FUNCTION__,
+                        r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,atoi(tmp+1),num_chips);
+                    return (FAILURE);
+                }
+                if(num_chips == 0)num_chips = 1;
+                for(int chp =0;(chp<num_chips);chp++){
+                    if(chip_ptr[chp].chip_num==-1)
+                        chip_ptr[chp].chip_num = chp;
+                }
+            }else {
+                errno = 0;
+                chip_num = strtol(chr_ptr[filt_idx][1],&end_ptr,10);
+                if(chip_num >= chips_in_this_node ||  errno != 0 || end_ptr == chr_ptr[filt_idx][1]){
+                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                    "for cpu_filer:%s,filter num:%d, chip filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,
+                    r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,chip_num,chips_in_this_node);
+                    return (FAILURE);
+                }
+                num_chips = 1;
+                if(chip_ptr[chip_num].chip_num == -1){
+                    chip_ptr[chip_num].chip_num = chip_num;
+                }
+                
+            }
+            r.filter.cf.node[n].num_chips = num_chips;
+            sprintf(msg_temp,"\nnode:%d,num_chips=%d:\t",n,num_chips);
+            strcat(msg,msg_temp);
+            for(int k=0;k<MAX_CHIPS_PER_NODE;k++){
+                if(chip_ptr[k].chip_num == -1)continue;
+                sprintf(msg_temp," %d \t",chip_ptr[k].chip_num);
+                strcat(msg,msg_temp);
+            }
+            for (int chp = 0; chp < MAX_CHIPS_PER_NODE; chp++) {
+                num_cores = 0;core_num=0;
+                cores_in_this_chip=get_num_of_cores_in_chip(n,chp);
+                if((chip_ptr[chp].chip_num  == -1) || (r.filter.cf.node[n].chip[chp].num_cores == cores_in_this_chip)){
+                    continue;
+                }
+                struct core_info *core_ptr = &r.filter.cf.node[n].chip[chp].core[0];
+                if (chr_ptr[filt_idx][2][0] == '*'){
+                        num_cores = cores_in_this_chip;
+                        for(int c = 0;(c<cores_in_this_chip); c++){
+                            if (core_ptr[c].core_num == -1)
+                                 core_ptr[c].core_num = c;
+                        }
+
+                } else if (strchr(chr_ptr[filt_idx][2],'[') != NULL) { /*indicates a range of cores is given in filter */
+
+                    if((tmp_str = (char*)malloc(strlen(chr_ptr[filt_idx][2])+2)) == NULL){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:malloc failed with errno %d(%s) for size = %d\n"
+                                ,__LINE__,__FUNCTION__,errno,strerror(errno),(strlen(chr_ptr[filt_idx][2])+2));
+                        return FAILURE;
+                    }
+                    j=0;
+                    strcpy(tmp_str,chr_ptr[filt_idx][2]);
+                    if((ptr[j++] = strtok(tmp_str,"[],")) == NULL){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s" 
+                        "for cpu_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,
+                        g_data.rules_file_name,filter_ptr[filt_idx],filt_idx);
+                        return (FAILURE);
+                    }
+                    while ((ptr[j]=strtok(NULL,",]")) != NULL ){
+                        j++;
+                    }
+                    errno=0;
+                    for(int k = 0;k<j;k++){
+
+                        if ((tmp = strchr(ptr[k],'%')) != NULL) { /* indicates a percentage of cores is given in filter */
+                            num_cores = (cores_in_this_chip * (float)((atoi(tmp+1))/100.0));
+                            if((num_cores < 0) ||  (num_cores > cores_in_this_chip)){
+                                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                    "for cpu_filer:%s,filter num:%d, core percentage as %d%(num_cores=%d)\n", __LINE__,__FUNCTION__,
+                                    r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,atoi(tmp+1),num_cores);
+                                return (FAILURE);
+                            }
+                            if(num_cores == 0)num_cores = 1;
+                            for(int core =0;(core<num_cores);core++){
+                                if (core_ptr[core].core_num == -1)
+                                core_ptr[core].core_num = core;
+                            }
+                        }else if (strchr(ptr[k],'-') == NULL){
+                            errno = 0;
+                            core_num = strtol(ptr[k],&end_ptr,10);
+                            if(core_num >= cores_in_this_chip ||  errno != 0 || end_ptr == ptr[k]){
+                                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                    "for cpu_filer:%s,filter num:%d, core filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,
+                                    r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,core_num,cores_in_this_chip);
+                                return (FAILURE);
+                            }
+                            if(core_ptr[core_num].core_num == -1){
+                                core_ptr[core_num].core_num = core_num;
+                            }
+                            num_cores++;
+                        }
+                        else {
+                            strcpy(c,ptr[k]);
+                            if((tmp=strtok(c,"-")) == NULL){
+                                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                    "for cpu_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                                    filter_ptr[filt_idx],filt_idx);
+                                return (FAILURE);
+
+                            }
+                            if((tmp=strtok(NULL,"-")) == NULL){
+                                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                    "for cpu_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                                    filter_ptr[filt_idx],filt_idx);
+                                return (FAILURE);
+
+                            }
+                            errno = 0;
+                            core_num = strtol(tmp,&end_ptr,10);
+                            if(core_ptr[core_num].core_num == -1){
+                                core_ptr[core_num].core_num = core_num;
+                            }
+                            if(core_num >= cores_in_this_chip ||  errno != 0 || end_ptr == ptr[k]){
+                                displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule file %s, rule file:%s "
+                                    "for cpu_filer:%s,filter num:%d, core field as %d ( must be < %d)\n", __LINE__,__FUNCTION__,
+                                    r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,core_num,cores_in_this_chip);
+                                 return (FAILURE);
+                            }
+                            errno = 0;
+                            for(int c=strtol(&ptr[k][0],&end_ptr,10);c <= core_num;c++){
+                                if(c >=cores_in_this_chip || errno != 0 || end_ptr == &ptr[k][0]){
+                                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                        "for cpu_filer:%s,filter num:%d, core filed as %d ( must be < %d)\n", __LINE__,__FUNCTION__,
+                                        r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,core_num,cores_in_this_chip);
+                                    return (FAILURE);
+                                }
+                                if(core_ptr[c].core_num==-1){
+                                    core_ptr[c].core_num=c;
+                                }
+                                num_cores++;
+
+                            }
+                        }
+                    }
+                    free(tmp_str);
+                }else if ((tmp = strchr(chr_ptr[filt_idx][2],'%')) != NULL) { /* indicates a percentage of cores is given in filter */
+
+                    num_cores = (cores_in_this_chip * (float)((strtol(tmp+1,&end_ptr,10))/100.0));
+                    if((num_cores < 0) ||  (num_cores > cores_in_this_chip)){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                            "for cpu_filer:%s,filter num:%d, core percentage as %d%(num_cores=%d)\n", __LINE__,__FUNCTION__,
+                            r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,atoi(tmp+1),num_cores);
+                        return (FAILURE);
+                    }
+                    if(num_cores == 0)num_cores = 1;
+                    for(int c =0;(c<num_cores);c++){
+                        if(core_ptr[c].core_num == -1)
+                            core_ptr[c].core_num = c;
+                    }
+                }else {
+                    errno = 0;
+                    core_num = strtol(chr_ptr[filt_idx][2],&end_ptr,10);
+                    if(core_num >= cores_in_this_chip ||  errno != 0 || end_ptr == chr_ptr[filt_idx][2]){
+                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                            "for cpu_filer:%s,filter num:%d, core field as %d ( must be < %d)\n", __LINE__,__FUNCTION__,
+                            r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,core_num,cores_in_this_chip);
+                        return (FAILURE);
+                    }
+                    num_cores = 1;
+                    if(core_ptr[core_num].core_num == -1){
+                        core_ptr[core_num].core_num = core_num;
+                    }
+                }
+                r.filter.cf.node[n].chip[chp].num_cores = num_cores;
+                sprintf(msg_temp,"\nnode:%d chip: %d,num_cores=%d:\t",n,chp,num_cores);
+                strcat(msg,msg_temp);
+                for(int k=0;k<MAX_CORES_PER_CHIP;k++){
+                    if(core_ptr[k].core_num == -1)continue;
+                    sprintf(msg_temp," %d \t",core_ptr[k].core_num);
+                    strcat(msg,msg_temp);
+                }
+                for (int cor = 0; cor < MAX_CORES_PER_CHIP; cor++) {
+                    num_cpus = 0;cpu_num=0;
+                    cpus_in_this_core= get_num_of_cpus_in_core(n,chp,cor);
+                    if((core_ptr[cor].core_num  == -1) || (r.filter.cf.node[n].chip[chp].core[cor].num_procs == cpus_in_this_core)){
+                        continue;
+                    }
+                    unsigned int *thread_ptr = &r.filter.cf.node[n].chip[chp].core[cor].lprocs[0];
+                    if (chr_ptr[filt_idx][3][0] == '*'){
+                            num_cpus = cpus_in_this_core;
+                            for(int t = 0;t<cpus_in_this_core;t++)
+                                thread_ptr[t] = get_logical_cpu_num(n,chp,cor,t);
+
+                    } else if (strchr(chr_ptr[filt_idx][3],'[') != NULL) { /*indicates a range of cores is given in filter */
+
+                        if((tmp_str = (char*)malloc(strlen(chr_ptr[filt_idx][3])+2)) == NULL){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:malloc failed with errno %d(%s) for size = %d\n"
+                                    ,__LINE__,__FUNCTION__,errno,strerror(errno),(strlen(chr_ptr[filt_idx][3])+2));
+                            return FAILURE;
+                        }
+                        j=0;
+                        strcpy(tmp_str,chr_ptr[filt_idx][3]);
+                        if((ptr[j++] = strtok(tmp_str,"[],")) == NULL){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                "for cpu_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,
+                            g_data.rules_file_name,filter_ptr[filt_idx],filt_idx);
+                            return (FAILURE);
+                        }
+
+                        while ((ptr[j]=strtok(NULL,",]")) != NULL ){
+                            j++;
+                        }
+                        errno=0;
+                        for(int k = 0;k<j;k++){
+                            if ((tmp = strchr(ptr[k],'%')) != NULL) { /* indicates a percentage of cores is given in filter */
+                                num_cpus = (cpus_in_this_core * (float)((atoi(tmp+1))/100.0));
+                                if((num_cpus < 0) ||  (num_cpus > cpus_in_this_core)){
+                                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                        "for cpu_filer:%s,filter num:%d, cpu percentage as %d%(num_cpus=%d)\n", __LINE__,__FUNCTION__,
+                                        r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,atoi(tmp+1),num_cpus); 
+                                    return (FAILURE);
+                                }
+                                if(num_cpus == 0)num_cpus = 1;
+                                for(int t =0;(t<num_cpus);t++){
+                                    if (thread_ptr[t] == -1)
+                                        thread_ptr[t] = get_logical_cpu_num(n,chp,cor,t);
+                                }
+
+                            }else if (strchr(ptr[k],'-') == NULL){
+                                errno = 0;
+                                cpu_num = strtol(ptr[k],&end_ptr,10);
+                                if(cpu_num >= cpus_in_this_core ||  errno != 0 || end_ptr == ptr[k]){
+                                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                        "for cpu_filer:%s,filter num:%d, thread field as %d ( must be < %d)\n", __LINE__,__FUNCTION__,
+                                        r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,cpu_num,cpus_in_this_core);
+                                    return (FAILURE);
+                                }
+                                if(thread_ptr[cpu_num]== -1){
+                                    thread_ptr[cpu_num]= get_logical_cpu_num(n,chp,cor,cpu_num);
+                                }
+                                num_cpus++;
+                            }
+                            else {
+                                strcpy(c,ptr[k]);
+                                if((tmp=strtok(c,"-")) == NULL){
+                                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                        "cpu_filer:%s,filter num:%d\n", __LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                                        filter_ptr[filt_idx],filt_idx);
+                                    return (FAILURE);
+
+                                }
+                                if((tmp=strtok(NULL,"-")) == NULL){
+                                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                        "for cpu_filer:%s,filter num:%d\n",__LINE__,__FUNCTION__,r.rule_id,g_data.rules_file_name,
+                                        filter_ptr[filt_idx],filt_idx);
+                                    return (FAILURE);
+
+                                }
+                                errno = 0;
+                                cpu_num = strtol(tmp,&end_ptr,10);
+                                if(thread_ptr[cpu_num]== -1){
+                                    thread_ptr[cpu_num] = get_logical_cpu_num(n,chp,cor,cpu_num);
+                                }
+                                if(cpu_num >= cpus_in_this_core ||  errno != 0 || end_ptr == ptr[k]){
+                                    displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                        "for cpu_filer:%s,filter num:%d, thread field as %d ( must be < %d)\n", __LINE__,__FUNCTION__,r.rule_id,
+                                        g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,cpu_num,cpus_in_this_core);
+                                     return (FAILURE);
+                                }
+                                errno = 0;
+                                for(int t=strtol(&ptr[k][0],&end_ptr,10);t<= cpu_num;t++){
+                                    if(t >=cpus_in_this_core || errno != 0 || end_ptr == &ptr[k][0]){
+                                        displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                            "for cpu_filer:%s,filter num:%d, thread field as %d ( must be < %d)\n", __LINE__,__FUNCTION__,
+                                            r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,cpu_num,cpus_in_this_core);
+                                        return (FAILURE);
+                                    }
+                                    if(thread_ptr[t] == -1){
+                                         thread_ptr[t]=get_logical_cpu_num(n,chp,cor,t);
+                                    }
+                                    num_cpus++;
+
+                                }
+                            }
+                        }
+                        free(tmp_str);
+                    }else if ((tmp = strchr(chr_ptr[filt_idx][3],'%')) != NULL) { /* indicates a percentage of cores is given in filter */
+                        num_cpus = (cpus_in_this_core * (float)((atoi(tmp+1))/100.0));
+                        if((num_cpus < 0) ||  (num_cpus > cpus_in_this_core)){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                "for cpu_filer:%s,filter num:%d, thread percentage as %d%(num_cpus=%d)\n", __LINE__,__FUNCTION__,
+                                r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,atoi(tmp+1),num_cpus);
+                            return (FAILURE);
+                        }
+                        if(num_cpus == 0)num_cpus = 1;
+                        for(int t =0;(t<num_cpus);t++){
+                            if(thread_ptr[t]==-1)
+                                thread_ptr[t] = get_logical_cpu_num(n,chp,cor,t);
+                        }
+                    }else {
+                        errno = 0;
+                        cpu_num = strtol(chr_ptr[filt_idx][3],&end_ptr,10);
+                        if(cpu_num >= cpus_in_this_core ||  errno != 0 || end_ptr == chr_ptr[filt_idx][3]){
+                            displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:Improper value is provided in rule %s, rule file:%s "
+                                "for cpu_filer:%s,filter num:%d, cpu field as %d ( must be < %d)\n", __LINE__,__FUNCTION__,
+                                r.rule_id,g_data.rules_file_name,filter_ptr[filt_idx],filt_idx,cpu_num,cpus_in_this_core);
+                            return (FAILURE);
+                        }
+                        num_cpus = 1;
+                        if(thread_ptr[cpu_num] == -1){
+                            thread_ptr[cpu_num] = get_logical_cpu_num(n,chp,cor,cpu_num);
+                        }
+                    }
+                    r.filter.cf.node[n].chip[chp].core[cor].num_procs = num_cpus;
+                    sprintf(msg_temp,"\nnode:%d chip:%d core:%d,num_cpus=%d:\t",n,chp,cor,num_cpus);
+                    strcat(msg,msg_temp);
+                    for(int k=0;k<MAX_CPUS_PER_CORE;k++){
+                        sprintf(msg_temp," %d \t",thread_ptr[k]);
+                        strcat(msg,msg_temp);
+                    }
+                }
+
+            }
+        }
+
+        
+    }
+    displaym(HTX_HE_INFO,DBG_DEBUG_PRINT,"%s\n",msg);
+    return SUCCESS;
+}

--- a/bin/hxemem64/stride_operation.c
+++ b/bin/hxemem64/stride_operation.c
@@ -1,0 +1,437 @@
+/* IBM_PROLOG_BEGIN_TAG */
+/*
+ * Copyright 2003,2016 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "nest_framework.h"
+extern struct nest_global g_data;
+extern struct mem_exer_info mem_g;
+
+int do_stride_operation(int t){
+    int pi=0,seg,rc,misc_detected=0;
+    struct segment_detail sd;
+    void *shr_mem_cur_ptr;
+    int num_oper=0,nw=0,nr=0,nc=0;
+    int no_of_strides, oper_per_stride, count;
+    static int main_misc_count = 0;
+    int miscompare_count, trap_flag;
+    unsigned int seg_seed, seed;
+    struct thread_data* th = &g_data.thread_ptr[t];
+    struct mem_exer_thread_info *local_ptr = &(mem_g.mem_th_data[t]);
+    th->testcase_thread_details = (void *)local_ptr;
+
+    sd.oper = OPER_STRIDE;
+    if( (g_data.stanza_ptr->misc_crash_flag) && (g_data.kdb_level) ){
+        trap_flag = 1;    /* Trap is set */
+    }else{
+        trap_flag = 0;    /* Trap is not set */
+    }
+    if(g_data.stanza_ptr->attn_flag){
+        trap_flag = 2;    /* attn is set */
+    }
+
+    if (g_data.stanza_ptr->seed == 0 ) {
+        seed = (unsigned int)time(NULL);
+    } else {
+        seed = (unsigned int)g_data.stanza_ptr->seed;
+    }
+    for (num_oper =0;num_oper < g_data.stanza_ptr->num_oper; num_oper++){
+        for (seg=0;seg<local_ptr->num_segs;){
+            shr_mem_cur_ptr = (void *)local_ptr->seg_details[seg].shm_mem_ptr;
+            sd.page_index=local_ptr->seg_details[seg].page_size_index;
+            sd.seg_num=local_ptr->seg_details[seg].seg_num;
+            sd.seg_size=local_ptr->seg_details[seg].shm_size;
+            sd.owning_thread = local_ptr->seg_details[seg].owning_thread;
+            sd.cpu_owning_chip = local_ptr->seg_details[seg].cpu_chip_num;
+            sd.mem_owning_chip = local_ptr->seg_details[seg].mem_chip_num;;
+            sd.affinity_index  = g_data.stanza_ptr->affinity;
+            sd.thread_ptr_addr = (unsigned long)th;
+            sd.global_ptr_addr = (unsigned long)&g_data;
+            sd.sub_seg_num=0;
+            sd.sub_seg_size=0;
+            seg_seed = seed;
+
+            if( g_data.stanza_ptr->pattern_type[pi] == PATTERN_ADDRESS ) {
+                sd.width = LS_DWORD;
+            } else {
+                sd.width = g_data.stanza_ptr->width;
+            }        
+            no_of_strides = (sd.seg_size / g_data.stanza_ptr->stride_sz);
+            oper_per_stride = (g_data.stanza_ptr->stride_sz / g_data.stanza_ptr->pattern_size[pi]);
+
+            nw = g_data.stanza_ptr->num_writes;
+            nr = g_data.stanza_ptr->num_reads;
+            nc = g_data.stanza_ptr->num_compares;
+
+            while(nw>0 || nr>0 || nc>0){
+                if(nw>0){
+                    seed = seg_seed;
+                    switch (sd.width) {
+                        case LS_DWORD:
+                            rc = write_dword(shr_mem_cur_ptr, no_of_strides, oper_per_stride, pi, &seed);
+                            break;
+                        case LS_WORD:
+                            rc = write_word(shr_mem_cur_ptr, no_of_strides, oper_per_stride, pi, &seed);
+                            break;
+                        case LS_BYTE:
+                            rc = write_byte(shr_mem_cur_ptr, no_of_strides, oper_per_stride, pi, &seed);
+                            break;
+                    }
+                    nw--;
+                }
+                if (g_data.exit_flag == 1) {
+                    goto exit;                
+                }
+                if(nr>0){
+                    switch (g_data.stanza_ptr->width) {
+                        case LS_DWORD:
+                            rc = read_dword(shr_mem_cur_ptr, no_of_strides, oper_per_stride);
+                            break;
+                        case LS_WORD:
+                            rc = read_word(shr_mem_cur_ptr, no_of_strides, oper_per_stride);
+                            break;
+                        case LS_BYTE:
+                            rc = read_byte(shr_mem_cur_ptr, no_of_strides, oper_per_stride);
+                            break;
+                    }
+                    nr--;
+                }
+                if (g_data.exit_flag == 1) {
+                    goto exit;
+                }
+                if(nc>0){
+                    seed = seg_seed;
+                    switch (g_data.stanza_ptr->width) {
+                        case LS_DWORD:
+                            rc = read_comp_dword(shr_mem_cur_ptr, no_of_strides, oper_per_stride, pi, &seed,trap_flag,&sd);
+                            break;
+                        case LS_WORD:
+                            rc = read_comp_word(shr_mem_cur_ptr, no_of_strides, oper_per_stride, pi, &seed,trap_flag,&sd);
+                            break;
+                        case LS_BYTE:
+                            rc = read_comp_byte(shr_mem_cur_ptr, no_of_strides, oper_per_stride, pi, &seed,trap_flag,&sd);
+                            break;
+                    }
+                    nc--;
+                }
+                if (g_data.exit_flag == 1) {
+                    goto exit;
+                }
+            }
+            if(rc != SUCCESS){/* If there is any miscompare, rc will have the offset */
+                miscompare_count = dump_miscompared_buffers(t,rc,seg,main_misc_count,&seg_seed,num_oper,trap_flag,pi,&sd);
+                STATS_VAR_INC(bad_others, 1);
+                main_misc_count++;
+                misc_detected++ ;
+                STATS_VAR_INC(bad_others, 1)
+                STATS_HTX_UPDATE(UPDATE)
+            }
+            if (g_data.exit_flag == 1) {
+                goto exit;
+            } /* endif */
+            switch(g_data.stanza_ptr->switch_pat) {
+                 case SW_PAT_ALL:               /* SWITCH_PAT_PER_SEG = ALL */
+                    /* Stay on this segment until all patterns are tested.
+                    Advance segment index once for every num_patterns */
+                    pi++;
+                    if (pi >= g_data.stanza_ptr->num_patterns) {
+                        pi = 0; /* Go back to the 1st pattern */
+                        seg++;        /* Move to the new Seg */
+                    }
+                     break;
+                case SW_PAT_ON:                /* SWITCH_PAT_PER_SEG = YES */
+                    /* Go back to the 1st pattern */
+                    pi++;
+                    if (pi >= g_data.stanza_ptr->num_patterns) {
+                        pi = 0;
+                    }
+                    /* Fall through */
+                case SW_PAT_OFF:                /* SWITCH_PAT_PER_SEG = NO */
+                    /* Fall through */
+                    default:
+                    seg++;        /* Increment Seg idx: case 1,0 and default */
+            } /* end of switch */
+
+        exit:
+            STATS_VAR_INC(bytes_writ,((g_data.stanza_ptr->num_writes - nw) * sd.seg_size))
+            STATS_VAR_INC(bytes_read,((g_data.stanza_ptr->num_reads - nr) * sd.seg_size))
+            STATS_VAR_INC(bytes_read,((g_data.stanza_ptr->num_compares - nc - misc_detected) * sd.seg_size))
+            STATS_HTX_UPDATE(UPDATE)
+            misc_detected = 0;
+            if (g_data.exit_flag == 1) {
+                return -1;
+            }
+        }/*seg loop*/
+
+    }/* num_oper loop*/
+    return SUCCESS;
+}
+/*******************************************************************************
+ *  fucntions to store a double word for nstride test case
+ *******************************************************************************/
+int write_dword(void *addr, int no_of_strides, int oper_per_stride, int pi, unsigned int *seed)
+{
+    unsigned long rand_no, *ptr = (unsigned long *) addr;
+    int k, l=0, m, n=0, i;
+
+    for (k=0; k < oper_per_stride; k++) { /* Outer loop for the no. of load/store oper. within a given stride */
+        for (m=0; m < no_of_strides; m++) {  /* Inner loop for the no. of stride in a given segment */
+			for(i=0; i < (g_data.stanza_ptr->pattern_size[pi]/g_data.stanza_ptr->width);i++){
+                if (g_data.stanza_ptr->pattern_type[pi] == PATTERN_ADDRESS) {
+                     ptr[l + i] = (unsigned long)(ptr + l + i);
+                } else if (g_data.stanza_ptr->pattern_type[pi] == PATTERN_RANDOM) {
+                    rand_no = (unsigned long)rand_r(seed);
+                    ptr[l + i] = rand_no;
+                    *seed = (unsigned int) rand_no;
+                } else {
+                    ptr[l + i] = *((unsigned long *)(g_data.stanza_ptr->pattern[pi] + i)); /* access pattern */
+                }
+            } /* End loop i */
+            l = l + g_data.stanza_ptr->stride_sz/g_data.stanza_ptr->width;
+        } /* End loop m */
+        n = n + g_data.stanza_ptr->pattern_size[pi]/g_data.stanza_ptr->width;
+        l = n;
+    }  /* End loop k */
+    return 0;
+} /* end write_dword */
+
+/*******************************************************************************
+ *  fucntions to read a double word for nstride test case
+ *******************************************************************************/
+int read_dword(void *addr, int no_of_strides, int oper_per_stride)
+{
+    unsigned long buf, *ptr = (unsigned long *) addr;
+    int k, l=0, m, n=0;
+
+    for (k=0; k < oper_per_stride; k++) { /* Outer loop for the no. of load/store oper. within a given stride */
+        for (m=0; m < no_of_strides; m++) {  /* Inner loop for the no. of stride in a given segment */
+            buf = ptr[l];
+            l = l + g_data.stanza_ptr->stride_sz/g_data.stanza_ptr->width;
+        } /* End loop m */
+        n = n + 1;
+        l = n;
+    }  /* End loop k */
+    return 0;
+} /* end read_dword */
+
+/*******************************************************************************
+ *  fucntions to read/Comp a double word for nstride test case
+ *******************************************************************************/
+int read_comp_dword(void *addr, int no_of_strides, int oper_per_stride, int pi, unsigned int *seed,int trap_flag,struct segment_detail *seg)
+{
+    unsigned long buf, expected_val, *ptr = (unsigned long *) addr;
+    int k, l=0, m, n=0, rc = 0, i;
+
+    for (k=0; k < oper_per_stride; k++) { /* Outer loop for the no. of load/store oper. within a given stride */
+        for (m=0; m < no_of_strides; m++) {  /* Inner loop for the no. of stride in a given segment */
+			for(i=0; i < (g_data.stanza_ptr->pattern_size[pi]/g_data.stanza_ptr->width);i++){
+                buf = ptr[l + i];
+                if (g_data.stanza_ptr->pattern_type[pi] == PATTERN_ADDRESS) {
+                    expected_val = (unsigned long)(ptr + l + i);
+                } else if (g_data.stanza_ptr->pattern_type[pi] == PATTERN_RANDOM) {
+                    expected_val = (unsigned long)rand_r(seed);
+                    *seed = (unsigned int) expected_val;
+                } else {
+                    expected_val = *((unsigned long *)(g_data.stanza_ptr->pattern[pi] + i)); /* access pattern */
+                }
+                if (buf != expected_val) {
+                    if(trap_flag){
+                    #ifndef __HTX_LINUX__
+                        trap(0xBEEFDEAD,(l+i),(unsigned long)addr,(unsigned long)expected_val,(unsigned long)(ptr + l + i),(unsigned long)seg,(unsigned long)g_data.stanza_ptr);
+                    #else
+                        do_trap_htx64(0xBEEFDEAD,(l+i),(unsigned long)addr,(unsigned long)expected_val,(unsigned long)(ptr + l + i),(unsigned long)seg,(unsigned long)g_data.stanza_ptr);
+                    #endif
+                    }
+                    rc = l + i + 1;
+                    return rc;
+                }
+            } /* End loop i */
+            l = l + g_data.stanza_ptr->stride_sz/g_data.stanza_ptr->width;
+        } /* End loop m */
+        n = n + g_data.stanza_ptr->pattern_size[pi]/g_data.stanza_ptr->width;
+        l = n;
+    }  /* End loop k */
+    return rc;
+} /* end read_comp_dword */
+
+/*******************************************************************************
+ *  fucntions to store a word for nstride test case
+ *******************************************************************************/
+int write_word(void *addr, int no_of_strides, int oper_per_stride, int pi, unsigned int *seed)
+{
+    unsigned int rand_no, *ptr = (unsigned int *) addr;
+    int k, l=0, m, n=0, i;
+
+    for (k=0; k < oper_per_stride; k++) { /* Outer loop for the no. of load/store oper. within a given stride */
+        for (m=0; m < no_of_strides; m++) {  /* Inner loop for the no. of stride in a given segment */
+            /*for(i=0; i < g_data.stanza_ptr->pattern_size[pi]; i+=g_data.stanza_ptr->width) {*/ /* Loop for pattern_size */
+			for(i=0; i < (g_data.stanza_ptr->pattern_size[pi]/g_data.stanza_ptr->width);i++){
+                if (g_data.stanza_ptr->pattern_type[pi] == PATTERN_RANDOM) {
+                    rand_no = (unsigned int)rand_r(seed);
+                    ptr[l + i] = rand_no;
+                    *seed = (unsigned int) rand_no;
+                } else {
+                    ptr[l + i] = *((unsigned int *)(g_data.stanza_ptr->pattern[pi] + i)); /* access pattern */
+                }
+            } /* End loop i */
+            l = l + g_data.stanza_ptr->stride_sz/g_data.stanza_ptr->width;
+        } /* End loop m */
+        n = n + g_data.stanza_ptr->pattern_size[pi]/g_data.stanza_ptr->width;
+        l = n;
+    }  /* End loop k */
+    return 0;
+} /* end write_word */
+
+/*******************************************************************************
+ *  fucntions to read a word for nstride test case
+ *******************************************************************************/
+int read_word(void *addr, int no_of_strides, int oper_per_stride)
+{
+    unsigned int buf, *ptr = (unsigned int *) addr;
+    int k, l=0, m, n=0;
+
+    for (k=0; k < oper_per_stride; k++) { /* Outer loop for the no. of load/store oper. within a given stride */
+        for (m=0; m < no_of_strides; m++) {  /* Inner loop for the no. of stride in a given segment */
+            buf = ptr[l];
+            l = l + g_data.stanza_ptr->stride_sz/g_data.stanza_ptr->width;
+        } /* End loop m */
+        n = n + 1;
+        l = n;
+    }  /* End loop k */
+    return 0;
+} /* end read_word */
+
+/*******************************************************************************
+ *  fucntions to read/Comp a word for nstride test case
+ *******************************************************************************/
+int read_comp_word(void *addr, int no_of_strides, int oper_per_stride, int pi, unsigned int *seed,int trap_flag,struct segment_detail *seg)
+{
+    unsigned int buf, expected_val, *ptr = (unsigned int *) addr;
+    int k, l=0, m, n=0, rc = 0, i;
+
+    for (k=0; k < oper_per_stride; k++) { /* Outer loop for the no. of load/store oper. within a given stride */
+        for (m=0; m < no_of_strides; m++) {  /* Inner loop for the no. of stride in a given segment */
+			for(i=0; i < (g_data.stanza_ptr->pattern_size[pi]/g_data.stanza_ptr->width);i++){
+                buf = ptr[l + i];
+                if (g_data.stanza_ptr->pattern_type[pi] == PATTERN_RANDOM) {
+                    expected_val = (unsigned int)rand_r(seed);
+                    *seed = (unsigned int) expected_val;
+                } else {
+                    expected_val = *((unsigned int *)(g_data.stanza_ptr->pattern[pi] + i)); /* access pattern */
+                }
+                if (buf != expected_val) {
+					if(trap_flag){
+					#ifndef __HTX_LINUX__
+						trap(0xBEEFDEAD,(l+i),(unsigned long)addr,(unsigned long)expected_val,(unsigned long)(ptr + l + i),(unsigned long)seg,(unsigned long)g_data.stanza_ptr);
+					#else
+						do_trap_htx64(0xBEEFDEAD,(l+i),(unsigned long)addr,(unsigned long)expected_val,(unsigned long)(ptr + l + i),(unsigned long)seg,(unsigned long)g_data.stanza_ptr);
+					#endif
+					}
+                    rc = l + i + 1;
+                    return rc;
+                }
+            } /* End loop i */
+            l = l + g_data.stanza_ptr->stride_sz/g_data.stanza_ptr->width;
+        } /* End loop m */
+        n = n + g_data.stanza_ptr->pattern_size[pi]/g_data.stanza_ptr->width;
+        l = n;
+    }  /* End loop k */
+    return rc;
+} /* end read_comp_word */
+
+/*******************************************************************************
+ *  fucntions to store a byte for nstride test case
+ *******************************************************************************/
+int write_byte(void *addr, int no_of_strides, int oper_per_stride, int pi, unsigned int *seed)
+{
+    char rand_no, *ptr = (char *) addr;
+    int k, l=0, m, n=0, i;
+
+    for (k=0; k < oper_per_stride; k++) { /* Outer loop for the no. of load/store oper. within a given stride */
+        for (m=0; m < no_of_strides; m++) {  /* Inner loop for the no. of stride in a given segment */
+			for(i=0; i < (g_data.stanza_ptr->pattern_size[pi]/g_data.stanza_ptr->width);i++){
+                if (g_data.stanza_ptr->pattern_type[pi] == PATTERN_RANDOM) {
+                    rand_no = (char)rand_r(seed);
+                    ptr[l + i] = rand_no;
+                    *seed = (unsigned int) rand_no;
+                } else {
+                    ptr[l + i] = *((char *)(g_data.stanza_ptr->pattern[pi] + i)); /* access pattern */
+                }
+            } /* End loop i */
+            l = l + g_data.stanza_ptr->stride_sz/g_data.stanza_ptr->width;
+        } /* End loop m */
+        n = (n + g_data.stanza_ptr->pattern_size[pi]/g_data.stanza_ptr->width);
+        l = n;
+    }  /* End loop k */
+    return 0;
+} /* end write_byte */
+
+/*******************************************************************************
+ *  fucntions to read a byte for nstride test case
+ *******************************************************************************/
+int read_byte(void *addr, int no_of_strides, int oper_per_stride)
+{
+    char buf, *ptr = (char *) addr;
+    int k, l=0, m, n=0;
+
+    for (k=0; k < oper_per_stride; k++) { /* Outer loop for the no. of load/store oper. within a given stride */
+        for (m=0; m < no_of_strides; m++) {  /* Inner loop for the no. of stride in a given segment */
+            buf = ptr[l];
+            l = l + g_data.stanza_ptr->stride_sz/g_data.stanza_ptr->width;
+        } /* End loop m */
+        n = n + 1;
+        l = n;
+    }  /* End loop k */
+    return 0;
+} /* end read_byte */
+
+/*******************************************************************************
+ *  fucntions to read/Comp a byte for nstride test case
+ *******************************************************************************/
+int read_comp_byte(void *addr, int no_of_strides, int oper_per_stride, int pi, unsigned int *seed,int trap_flag,struct segment_detail *seg)
+{
+    char buf, expected_val, *ptr = (char *) addr;
+    int k, l=0, m, n=0, rc = 0, i;
+
+    for (k=0; k < oper_per_stride; k++) { /* Outer loop for the no. of load/store oper. within a given stride */
+        for (m=0; m < no_of_strides; m++) {  /* Inner loop for the no. of stride in a given segment */
+			for(i=0; i < (g_data.stanza_ptr->pattern_size[pi]/g_data.stanza_ptr->width);i++){
+                buf = ptr[l + i];
+                if (g_data.stanza_ptr->pattern_type[pi] == PATTERN_RANDOM) {
+                    expected_val = (char)rand_r(seed);
+                    *seed = (unsigned int) expected_val;
+                } else {
+                    expected_val = *((char *)(g_data.stanza_ptr->pattern[pi] + i)); /* access pattern */
+                }
+                if (buf != expected_val) {
+                   	if(trap_flag){
+                    #ifndef __HTX_LINUX__
+                        trap(0xBEEFDEAD,(l+i),(unsigned long)addr,(unsigned long)expected_val,(unsigned long)(ptr + l + i),(unsigned long)seg,(unsigned long)g_data.stanza_ptr);
+                    #else
+                        do_trap_htx64(0xBEEFDEAD,(l+i),(unsigned long)addr,(unsigned long)expected_val,(unsigned long)(ptr + l + i),(unsigned long)seg,(unsigned long)g_data.stanza_ptr);
+                    #endif
+                    }
+                    rc = l + i + 1;
+                    return rc;
+                }
+            } /* End loop i */
+            l = l + g_data.stanza_ptr->stride_sz/g_data.stanza_ptr->width;
+        } /* End loop m */
+        n = n + g_data.stanza_ptr->pattern_size[pi]/g_data.stanza_ptr->width;
+        l = n;
+    }  /* End loop k */
+    return rc;
+} /* end read_comp_byte */
+

--- a/etc/scripts/create_ab_mem_mdt
+++ b/etc/scripts/create_ab_mem_mdt
@@ -30,7 +30,7 @@ P6Compatmode=`${HTXBIN}/show_syscfg pvr | grep -i Power6Compatmode | awk -F: '{p
 echo "Creating mdt.ab_mem ..."
 if [[ $proc_ver_dec -ge 63 && $P6Compatmode = "False" ]] # Shifts for P7 & above
 then
-    create_my_mdt mem:memmfg 							> ${HTXMDT}/mdt.ab_mem
+    create_my_mdt mem:default.mfg 							> ${HTXMDT}/mdt.ab_mem
 else
     cat ${HTXMDT}/mdt.mem  							> ${HTXMDT}/mdt.ab_mem
 fi

--- a/etc/scripts/create_shift_mem_L4test.awk
+++ b/etc/scripts/create_shift_mem_L4test.awk
@@ -35,7 +35,7 @@ system("cat ${HTXMDT}mdt.all | create_mdt_with_devices.awk");
 
 for (i=0; i < no_of_chips; i++) {
     mem_inst = sprintf("mem%d", i);
-    mkstanza("hxemem64","64bit","memory",mem_inst,"hxemem64",rule_file,rule_file);
+    mkstanza("hxecentaur","64bit","memory",mem_inst,"hxemem64",rule_file,rule_file);
     cont_on_err("NO");
     printf("\n");
 }

--- a/etc/scripts/devconfig
+++ b/etc/scripts/devconfig
@@ -76,26 +76,26 @@
 	create_my_mdt cache:$cache_sw_prefetch_rf > ${HTXMDT}/mdt.cache.sw_prefetch
 	create_my_mdt cache:rules.l2_and_l3_bounce > ${HTXMDT}/mdt.cache.l2_and_l3_bounce
 	
-	create_my_mdt mem:memmfg.nodelay > ${HTXMDT}/mdt.mem
-	create_my_mdt mem:memmfg.nodelay tlbie: > ${HTXMDT}/mdt.mem_tlbie
+	create_my_mdt mem:default.mfg.nodelay > ${HTXMDT}/mdt.mem
+	create_my_mdt mem:default tlbie:tlbie > ${HTXMDT}/mdt.mem_tlbie
 	create_my_mdt mem:mem_16m_hwpf > ${HTXMDT}/mdt.mem.hw_prefetch
 	create_my_mdt mem:rules.dl1_reloads_from_caches > ${HTXMDT}/mdt.mem.dl1_reloads_from_caches
 	create_my_mdt mem:rules.max_cache_hit > ${HTXMDT}/mdt.mem.max_cache_hit
 	create_my_mdt mem:rules.max_cache_miss > ${HTXMDT}/mdt.mem.max_cache_miss
 	
-	create_my_mdt sctu: cache:$cache_rf mem:memmfg tlbie:tlbie > ${HTXMDT}/mdt.nest
+	create_my_mdt sctu: cache:$cache_rf mem:default.char tlbie:tlbie > ${HTXMDT}/mdt.nest
 	create_my_mdt sctu:rules.CacheBias > ${HTXMDT}/mdt.cachebias
 	create_my_mdt tlbie: > ${HTXMDT}/mdt.tlbie
 	
 	# Create mdt.mem_nest having reduced sctu devices.
 	# sctu devices created are half compared to sctu devices in mdt.bu
         echo "Creating mdt.mem_nest ..."
-	create_my_mdt cache:$cache_sw_prefetch_rf mem:memmfg > ${HTXMDT}/mdt.mem_nest
+	create_my_mdt cache:$cache_sw_prefetch_rf mem:default > ${HTXMDT}/mdt.mem_nest
 	create_my_sctu_stanzas.awk MEM_NEST >> ${HTXMDT}/mdt.mem_nest
     
 	# Create mdt.bu.characterization having only 1 sctu server per gang.
 	# Number of sctu servers per gang is reduced to get optimum fmax results.
-	create_my_mdt fpu:fpu_cpu_combo.p8 mem:memmfg > ${HTXMDT}/mdt.bu_char
+	create_my_mdt fpu:fpu_cpu_combo.p8 mem:default.char nvidia:default.char > ${HTXMDT}/mdt.bu_char
 	cat ${HTXMDT}mdt.bu | create_mdt_without_devices.awk default cpu fpu sctu mem >> ${HTXMDT}/mdt.bu_char
 	create_my_sctu_stanzas.awk CHARACTERIZATION >> ${HTXMDT}mdt.bu_char
 
@@ -214,8 +214,8 @@
 		create_my_mdt $hxestorage_4K_rand_read > ${HTXMDT}/mdt.storage_4K_rand_read
 	fi
 	
-	create_my_mdt $hxestorage_default mem:memmfg ven:default > ${HTXMDT}/mdt.mem.io
-	create_my_mdt $hxestorage_default ven:default mem:memmfg cache:$cache_rf sctu: tlbie:tlbie > ${HTXMDT}/mdt.nest.io
+	create_my_mdt $hxestorage_default mem:default ven:default > ${HTXMDT}/mdt.mem.io
+	create_my_mdt $hxestorage_default ven:default mem:default cache:$cache_rf sctu: tlbie:tlbie > ${HTXMDT}/mdt.nest.io
 	create_my_mdt $hxestorage_cache ven:default cache:$cache_rf sctu: > ${HTXMDT}/mdt.cache.io
 	create_my_mdt mem:rules.comm_db_pk $hxestorage_comm_db_pk cpu:rules.comm_db_pk  > ${HTXMDT}/mdt.comm_db_pk
         create_my_mdt $hxestorage_app_server mem:rules.app_server > ${HTXMDT}/mdt.app_server #mdt for application or middleware server

--- a/etc/scripts/htxconf.awk
+++ b/etc/scripts/htxconf.awk
@@ -421,10 +421,13 @@ BEGIN {
 		no_pages_reserved_per_instance = 64;
 		rule_file_name=sprintf("default.p7");
 	}
-	else if(proc_ver == "4b" || proc_ver == "4c" || proc_ver == "4d" ) {
+	else if(proc_ver == "4b" || proc_ver == "4d" || proc_ver == "4c" ) {
 		no_pages_reserved_per_instance = 32;
 		rule_file_name=sprintf("default.p8");
 	}
+    else if(proc_ver == "4e" || proc_ver == "4f" ) {
+        rule_file_name=sprintf("default.p9");
+    }
 	if ( proc_os == "POWER6" ) {
 		rule_file_name=sprintf("default.p6");
 	}
@@ -754,15 +757,15 @@ function create_memory_stanzas() {
 	if (CMVC_RELEASE != "htxltsbml") {
 		ams=snarf("cat /proc/ppc64/lparcfg 2> /dev/null | grep cmo_enabled | awk -F= '{print $2}'")
 		if (ams == "1") {
-			system("awk '/.*/ { if ($0 ~ /^max_mem/ )printf(\"max_mem = yes\\nmem_percent = 40\\n\"); else print $0; }' ${HTXREGRULES}/hxemem64/maxmem > ${HTXREGRULES}/hxemem64/maxmem.ams");
-			mkstanza("hxemem64","64bit","memory","mem","hxemem64","maxmem.ams","maxmem.ams");
+			system("awk '/.*/ { if ($0 ~ /^global_alloc_mem_percent/ )printf(\"global_alloc_mem_percent = 40\\n\"); else print $0; }' ${HTXREGRULES}/hxemem64/default > ${HTXREGRULES}/hxemem64/default.ams");
+			mkstanza("hxemem64","64bit","memory","mem","hxemem64","default.ams","default.ams");
         }
 		else {
-			mkstanza("hxemem64","64bit","memory","mem","hxemem64","maxmem","maxmem");
+			mkstanza("hxemem64","64bit","memory","mem","hxemem64","default","default");
 		}
 	}
 	else {
-		mkstanza("hxemem64","64bit","memory","mem","hxemem64","maxmem","maxmem");
+		mkstanza("hxemem64","64bit","memory","mem","hxemem64","default","default");
 	}
 	load_seq(65535);
 	loop_cnt=((log_proc-(log_proc%2))/2);

--- a/rules/reg/hxemem64/Makefile
+++ b/rules/reg/hxemem64/Makefile
@@ -21,8 +21,14 @@ TARGET= \
              rules.app_server \
              rules.hpc_comp_node \
              rules.MBA \
- 		mem.eq.50 \
-		mem.eq.90
+      		 mem.eq.50 \
+	    	 mem.eq.90 \
+             default \
+             default.char \
+             default.less \
+             default.eq \
+             default.mfg \
+             default.mfg.nodelay
 
 
 .PHONY: all clean

--- a/rules/reg/hxemem64/default
+++ b/rules/reg/hxemem64/default
@@ -1,0 +1,74 @@
+* IBM_PROLOG_BEGIN_TAG 
+* This is an automatically generated prolog. 
+*  
+* htxubuntu src/htx/usr/lpp/htx/rules/reg/hxemem64/default 1.2 
+*  
+* Licensed Materials - Property of IBM 
+*  
+* COPYRIGHT International Business Machines Corp. 2016 
+* All Rights Reserved 
+*  
+* US Government Users Restricted Rights - Use, duplication or 
+* disclosure restricted by GSA ADP Schedule Contract with IBM Corp. 
+*  
+* IBM_PROLOG_END_TAG 
+**The default rule file allocates 70% of free memory available in the partition, 
+**Each stanza has differant stress test case in terms of oper/memory access width/pattern,  
+**that exercises allocated memory dependng mem_filetr and cpu_filter parameter.
+**Please read the documnetation htxmem64.readme for explaination of rule parameters.
+****************************************************************************************
+***Global Rules****
+global_alloc_mem_percent = 70
+global_disable_cpu_bind  = NO
+**************************
+rule_id = mem_1
+oper = mem
+num_oper = 1
+pattern_id = ADDRESS 0x5555555555555555
+switch_pat_per_seg = all
+width = 8
+affinity = local
+
+rule_id = mem_remote_2
+oper = mem
+num_oper = 1
+pattern_id = RANDOM HEXFF(8)
+width = 4
+affinity = remote_chip
+
+rule_id = mem_3
+oper = mem
+num_oper = 1
+pattern_id = 0xAAAAAAAAAAAAAAAA
+width = 1
+affinity = local
+
+rule_id = stride_4
+oper = stride
+num_oper = 1
+pattern_id = HEXFF(8) ADDRESS HEXZEROS(8)
+width = 8
+affinity = local
+mem_filter = N*P*[4K_50%,64K_50%,2M_100%,16M_100%]
+
+rule_id = rim_5
+oper = rim
+num_oper = 1
+pattern_id = 0x3333333333333333
+width = 8
+cpu_filter = N*P*C*T50%
+mem_filter = N*P*[4k_10%,64K_10%,2M_100%,16M_100%]
+seg_size_16M = 2097152
+seg_size_4K  = 2097152
+seg_size_64K = 2097152
+
+rule_id = dma_6
+oper = dma
+num_oper = 1
+pattern_id = HEXZEROS(4096)
+width = 8
+cpu_filter = N*P*C*T0
+mem_filter = N*P*[4k_100MB,64K_100MB]
+seg_size_4K  = 2097152
+seg_size_64K = 2097152
+seg_size_16M = 2097152

--- a/rules/reg/hxemem64/default.char
+++ b/rules/reg/hxemem64/default.char
@@ -1,0 +1,38 @@
+* IBM_PROLOG_BEGIN_TAG 
+* This is an automatically generated prolog. 
+*  
+* htxubuntu src/htx/usr/lpp/htx/rules/reg/hxemem64/default.char 1.2 
+*  
+* Licensed Materials - Property of IBM 
+*  
+* COPYRIGHT International Business Machines Corp. 2016 
+* All Rights Reserved 
+*  
+* US Government Users Restricted Rights - Use, duplication or 
+* disclosure restricted by GSA ADP Schedule Contract with IBM Corp. 
+*  
+* IBM_PROLOG_END_TAG 
+**With this rule exerciser attempts to drive max bandwidth with 40% of free 
+**memory which will be exercised by 50% of cpus from every core.
+**Please read the documnetation htxmem64.readme for explaination of rule parameters.
+****************************************************************************************
+*******Global Rules**********
+global_startup_delay = 90
+global_alloc_mem_percent = 40
+global_disable_cpu_bind  = NO
+global_disable_filters = no
+*********************************
+rule_id = mem_stride_test
+oper = stride
+pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA 0xCCCCCCCCCCCCCCCC 0x3333333333333333 0x0F0F0F0F0F0F0F0F 0x3C3C3C3C3C3C3C3C 0x5A5A5A5A5A5A5A5A
+switch_pat_per_seg = all
+num_oper = 100
+num_writes = 1
+num_read_only = 1
+num_read_comp = 1
+width = 8
+affinity = local
+disable_cpu_bind = NO
+cpu_filter = N*P*C*T%50
+mem_filter = N*P*[4K_100%,64K_100%,2M_100%,16M_100%]
+

--- a/rules/reg/hxemem64/default.eq
+++ b/rules/reg/hxemem64/default.eq
@@ -1,0 +1,29 @@
+* IBM_PROLOG_BEGIN_TAG 
+* This is an automatically generated prolog. 
+*  
+* htxubuntu src/htx/usr/lpp/htx/rules/reg/hxemem64/default.eq 1.1 
+*  
+* Licensed Materials - Property of IBM 
+*  
+* COPYRIGHT International Business Machines Corp. 2016 
+* All Rights Reserved 
+*  
+* US Government Users Restricted Rights - Use, duplication or 
+* disclosure restricted by GSA ADP Schedule Contract with IBM Corp. 
+*  
+* IBM_PROLOG_END_TAG 
+*******Global Rules**********
+global_alloc_huge_page = no
+global_disable_filters = no
+*********************************
+rule_id = mem_eq_test
+oper = mem
+pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555
+switch_pat_per_seg = all
+num_oper = 10
+num_writes = 1
+num_read_only = 1
+num_read_comp = 1
+width = 8
+affinity = local
+mem_filter = N*P*[4K_100%,64K_100%]

--- a/rules/reg/hxemem64/default.less
+++ b/rules/reg/hxemem64/default.less
@@ -1,0 +1,82 @@
+* IBM_PROLOG_BEGIN_TAG 
+* This is an automatically generated prolog. 
+*  
+* htxubuntu src/htx/usr/lpp/htx/rules/reg/hxemem64/default.less 1.1 
+*  
+* Licensed Materials - Property of IBM 
+*  
+* COPYRIGHT International Business Machines Corp. 2016 
+* All Rights Reserved 
+*  
+* US Government Users Restricted Rights - Use, duplication or 
+* disclosure restricted by GSA ADP Schedule Contract with IBM Corp. 
+*  
+* IBM_PROLOG_END_TAG 
+**The default.less is specially for DR/Hotplug operations, 
+** it allocates 40% of free memory and disables cpu bind for its entire run.
+**Each stanza has differant stress test case in terms of oper/memory access width/pattern,
+**that exercises allocated memory dependng mem_filetr.The cpu_filter parameter only tells about num of threads.
+**Please read the documnetation htxmem64.readme for explaination of rule parameters.
+****************************************************************************************
+***Global Rules****
+global_alloc_mem_percent = 40
+global_disable_cpu_bind  = NO
+global_disable_cpu_bind = yes
+**************************
+rule_id = mem_1
+oper = mem
+num_oper = 1
+pattern_id = ADDRESS 0x5555555555555555
+switch_pat_per_seg = all
+width = 8
+affinity = local
+disable_cpu_bind = yes
+
+rule_id = mem_remote_2
+oper = mem
+num_oper = 1
+pattern_id = RANDOM HEXFF(8)
+width = 4
+affinity = remote_chip
+disable_cpu_bind = yes
+
+rule_id = mem_3
+oper = mem
+num_oper = 1
+pattern_id = 0xAAAAAAAAAAAAAAAA
+width = 1
+affinity = local
+disable_cpu_bind = yes
+
+rule_id = stride_4
+oper = stride
+num_oper = 1
+pattern_id = HEXFF(8) ADDRESS HEXZEROS(8)
+width = 8
+affinity = local
+mem_filter = N*P*[4K_50%,64K_50%,2M_100%,16M_100%]
+disable_cpu_bind = yes
+
+rule_id = rim_5
+oper = rim
+num_oper = 1
+pattern_id = 0x3333333333333333
+width = 8
+cpu_filter = N*P*C*T50%
+mem_filter = N*P*[4k_10%,64K_10%,2M_100%,16M_100%]
+seg_size_16M = 2097152
+seg_size_4K  = 2097152
+seg_size_64K = 2097152
+disable_cpu_bind = yes
+
+rule_id = dma_6
+oper = dma
+num_oper = 1
+pattern_id = HEXZEROS(4096)
+width = 8
+cpu_filter = N*P*C*T0
+mem_filter = N*P*[4k_100MB,64K_100MB]
+seg_size_4K  = 2097152
+seg_size_64K = 2097152
+seg_size_16M = 2097152
+disable_cpu_bind = yes

--- a/rules/reg/hxemem64/default.mfg
+++ b/rules/reg/hxemem64/default.mfg
@@ -1,0 +1,37 @@
+* IBM_PROLOG_BEGIN_TAG 
+* This is an automatically generated prolog. 
+*  
+* htxubuntu src/htx/usr/lpp/htx/rules/reg/hxemem64/default.mfg 1.2 
+*  
+* Licensed Materials - Property of IBM 
+*  
+* COPYRIGHT International Business Machines Corp. 2016 
+* All Rights Reserved 
+*  
+* US Government Users Restricted Rights - Use, duplication or 
+* disclosure restricted by GSA ADP Schedule Contract with IBM Corp. 
+*  
+* IBM_PROLOG_END_TAG 
+**This rule is for mfg testing, consumes 90% of memory using all cpu resources,
+**Each segment is filled with 9 different patterns.
+**Please read the documnetation htxmem64.readme for explaination of rule parameters.
+****************************************************************************************
+*******Global Rules**********
+global_startup_delay = 90
+global_alloc_mem_percent = 90
+global_disable_cpu_bind  = NO
+global_disable_filters = no
+*********************************
+rule_id = mem_stride_test
+oper = stride
+pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA 0xCCCCCCCCCCCCCCCC 0x3333333333333333 0x0F0F0F0F0F0F0F0F 0x3C3C3C3C3C3C3C3C 0x5A5A5A5A5A5A5A5A
+switch_pat_per_seg = all
+num_oper = 500
+num_writes = 1
+num_read_only = 1
+num_read_comp = 1
+width = 8
+affinity = local
+disable_cpu_bind = NO
+cpu_filter = N*P*C*T*
+mem_filter = N*P*[4K_100%,64K_100%,2M_100%,16M_100%]

--- a/rules/reg/hxemem64/default.mfg.nodelay
+++ b/rules/reg/hxemem64/default.mfg.nodelay
@@ -1,39 +1,37 @@
 * IBM_PROLOG_BEGIN_TAG 
 * This is an automatically generated prolog. 
 *  
-* htx72F src/htx/usr/lpp/htx/rules/reg/hxemem64/mem_16m_hwpf 1.3 
+* htxubuntu src/htx/usr/lpp/htx/rules/reg/hxemem64/default.mfg.nodelay 1.1 
 *  
 * Licensed Materials - Property of IBM 
 *  
-* COPYRIGHT International Business Machines Corp. 2010 
+* COPYRIGHT International Business Machines Corp. 2016 
 * All Rights Reserved 
 *  
 * US Government Users Restricted Rights - Use, duplication or 
 * disclosure restricted by GSA ADP Schedule Contract with IBM Corp. 
 *  
 * IBM_PROLOG_END_TAG 
-* Targeted at concurrent operations with 16M pages and hardware prefetch
-* This rule stanza creates Cache to memory traffic by working with 16M page
-* creating hardware prefetch operations in the process
-* 8 byte width of operations:
-*Note: Please make sure 16M pages are enabled on test system.
-***********************************************************************************
+**This rule is for mfg testing, consumes 90% of memory using all cpu resources,
+**Each segment is filled with 9 different patterns.
+**Please read the documnetation htxmem64.readme for explaination of rule parameters.
+****************************************************************************************
 *******Global Rules**********
 global_startup_delay = 0
-global_alloc_mem_percent = 5
+global_alloc_mem_percent = 90
+global_disable_cpu_bind  = NO
 global_disable_filters = no
 *********************************
-rule_id = MEM_HPF
+rule_id = mem_stride_test
+oper = stride
 pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA 0xCCCCCCCCCCCCCCCC 0x3333333333333333 0x0F0F0F0F0F0F0F0F 0x3C3C3C3C3C3C3C3C 0x5A5A5A5A5A5A5A5A
-num_oper = 9999
+switch_pat_per_seg = all
+num_oper = 500
 num_writes = 1
-num_read_only = 0
+num_read_only = 1
 num_read_comp = 1
-switch_pat_per_seg = YES
-disable_cpu_bind = no
-oper = mem
 width = 8
 affinity = local
+disable_cpu_bind = NO
 cpu_filter = N*P*C*T*
-mem_filter = N*P*[16M_100%]
-
+mem_filter = N*P*[4K_100%,64K_100%,2M_100%,16M_100%]

--- a/rules/reg/hxemem64/hxemem64.readme
+++ b/rules/reg/hxemem64/hxemem64.readme
@@ -1,344 +1,310 @@
-
-README for hxemem64 
-=====================
-
+* IBM_PROLOG_BEGIN_TAG 
+* This is an automatically generated prolog. 
+*  
+* htxubuntu src/htx/usr/lpp/htx/rules/reg/hxemem64/hxemem64.readme 1.4.5.3 
+*  
+* Licensed Materials - Property of IBM 
+*  
+* COPYRIGHT International Business Machines Corp. 2010 
+* All Rights Reserved 
+*  
+* US Government Users Restricted Rights - Use, duplication or 
+* disclosure restricted by GSA ADP Schedule Contract with IBM Corp. 
+*  
+* IBM_PROLOG_END_TAG 
+README for hxemem64
 (1) Goal:
 ---------
-The goal of hxemem64 exerciser is to stress test the memory subsystem in a multitasking 
-environment.
+The goal of hxemem64 exerciser is to stress test the nest portion of POWER systems (L3,X-bus,A-bus,Centaur,memory subsystem) in a multitasking environment.
 
 (2) Salient Features:
----------------------
-
-1.Supports testing of various page sizes, segments (including MPSS).
+----------------------------
+1.Supports exercising of various page sizes and segments.
 2.Supports concurrent test case to stress all memory controllers of the system in parallel.
-3.Supports various patterns, read/write ratios.
+3.Provides controlling option of memory workload for every supported page pool at each chip level.
+4.Provides controlling option of cpu workload at Node->Chip->Core->Threads level.
+3.Supports various patterns, read/write/read_compare ratios.
 4.Supports specifying a stride for memory access pattern.
 
 (3) Hardware supported & HW test scope:
 ---------------------------------------
-Hxemem64 exerciser is supported on all POWER platforms.
-MPSS test case is supported only on Power6 and later HW running AIX610 or later version.
-eMPSS test case is supported only on power7 and later HW running AIX61L or later version.
+Hxemem64 exerciser is supported on all POWER platforms. 
 
-(4) Supported OS:
+(4) OS support:
 -----------------
 AIX: y
 Linux: y
 BML: y
 
 (5) General info:
------------------
-hxemem64 test program runs as user application on top of OS (AIX, BML & Linux).
-mdt.mem is a special mdt to drive high memory bandwidth.
-Rule file parameters decide how many cpu threads are used to drive memory controllers.
-For testing large pages, prior configuration of large pages should be done before 
-running HTX.
-In case of Dynamic reconfiguration, if any CPU’s are removed exerciser will check
-whether any thread is bound to that particular CPU if yes then it will be unbond.
-And in next stanza it will bound with the available CPU’s.
-
-To configure large pages on Linux, use following command:
+-----------------------
+hxemem64 test program runs as a user application on top of OS (AIX, BML & Linux).  It supports memory exercising/stress testing at both levels/modes i.e 
+"system memory view" and "chip memory view" , which can be controlled through rule file parameter "global_disable_fliters". 
+For high performance test  i.e to drive high memory bandwidth and to have control on cpus and memory usage (by using cpu and mem filters facility in rule),
+it is necessary to run hxemem64 in "chip memory view mode" by making global rule "global_disable_filter = no" for a given rule file. 
+For exercising huge/large pages, prior configuration of pages should be done before running HTX (This is currently done during HTX initial setup time). 
+To configure large pages, use following commands:
+Linux:
 echo <no_of_large_pages>  > /proc/sys/vm/nr_hugepages
-
+AIX:
 vmo command can be used to configure large pages on AIX.
 16G pages need to be configured through HMC.
 
+In case of Dynamic reconfiguration, if any CPU is removed exerciser will check whether any thread is bound to that CPU, if yes then it will be unbound.
+And from next stanza, it will be a free floating cpu workload (runs without binding to any cpu).
+
 (6) Prerequisites:
 ---------------------
-System should have enough paging/swap space as per the AIX/Linux Performance tuning guidelines 
-for normal operation.  As a general rule the paging/swap space available should be approximately
-1.5 times of total memory available.
+System must be in well balanced configuration with respect to cpus and memory, i.e every available chip must have both cpus and memory in it. 
+System should have enough paging/swap space as per the AIX/Linux Performance tuning guidelines for normal operation. 
 
 (7) Description:
--------------------
-Objective of hxemem64 is to stress test the memory subsystem by performing various data 
-integrity tests. Exerciser has capability to test fixed amount of memory or % of free memory.
-Exerciser probes the available free memory configuration for every page pool 
-(4K, 64K, 16M and 16G page pools) and grabs % of memory from every page pool by allocating 
-shared memory segments. 
+-----------------
+Objective of hxemem64 is to stress test the memory subsystem by performing various data integrity tests.
+Exerciser has capability to test absolute amount or percentage of free memory or number of pages for all supported page sizes(4K, 64K, 2M, 16M and 16G page pools).
+Exerciser, during its initial setup stage probes the available free memory for every page pool and
+grabs percentage of memory from every page pool by allocating in shared memory segments. Later, based on the operation and filters at every stanza
+it decides what amount of memory per page pool is exercised. 
 
-Exerciser supports two types of testing modes: 
-1) normal
-2) concurrent
+Exerciser supports two types of testing modes:
+1)  system memory view.
+2)  chip memory view.
 
-Normal mode is a single threaded operation where in single thread performs write/read/compare
-operation on every memory segment with specified pattern(s). 
+System memory view, is enabled based on system/partition configuration. i.e. in following scenarios.
+	- when system is booted with shared processor mode.
+	- When there is imbalanced cpu and mem configuration, i.e If any of the chips in partition contains only cpus  and no memory  or only mem and no cpus in it.
+ 
+Chip memory view, is enabled in the following scenarios.
+	-When system is booted in dedicated processor mode.
+	-And when there is good balanced cpu and mem config detected on the partition, i.e  every  available chip  has both cpu and memory configured in it.
+	-One can force exercising memory at chip level (even if system having imbalanced config) by setting "global_disable_filters = yes". 
 
-Concurrent mode is a multi threaded operation where in available shared memory segments are 
-divided equally among the threads and all the threads perform write/read/compare (WRC) 
-operation on allotted segments with specified pattern(s).Threads performing WRC operation bind
-themselves to specific cpu. Exerciser attempts to grab local memory (node affinity) for each 
-thread due to performance reasons.Concurrent mode allows to drive high memory bandwidth across
-the system. 
-Mode can be specified through rule file parameter "mode".
+
+Default mode of action by exerciser based on system config: 
+==============================================================================================
+Chip no.        has cpu?         has memory? 	    Hxemem64 runs in mode           comments
+==============================================================================================
+      1       	   Y	      	 N   		     System memory view 	Filters disabled 
+      2            N             Y		     System memory view		Filters disabled
+      3            Y             Y                   Chip memory view		Filters enabled
+      4            N             N                   Ignore			N.A.
 
 There are three types of WRC operations supported
 1)MEM
-When oper = MEM, entire shared memory segment is written using specified pattern. 
-Later, read/compare operation is performed from beginning of the shared memory segment.
+When oper = MEM, entire shared memory segment is written using specified pattern.
+Later, read/read_compare operation is performed from beginning of the shared memory segment.
+
 2)DMA
-When oper = DMA, shared memory segment is filled through a DMA from disk in the chunks 
-of specified pattern size. The pattern file should exist on the disk. Later, read/compare 
-operation happens like MEM.
+When oper = DMA, shared memory segment is filled through a DMA from disk in chunks
+of specified pattern size. The pattern file should exist on the disk. Later, read/read_compare
+operation will be performed like MEM.
+
 3)RIM
-When oper = WRFR, i.e. Write/Read/Flush/Read and then compare.shared memory segment is 
-written in 1/2/4/8 bytes at a time and read/compare operations follow immediately.
+When oper = RIM, i.e. Write/Read/Flush/Read and then compare.
+
+4)STRIDE
+When oper =STRIDE, it will introduce a stride in the memory access pattern. 
+The stride size for accessing the memory is defined through a rulefile parameter "stride_sz". 
+By default, its value is 128 byte(1 cacheline).
+The main intention of this test case is to have more cache misses i.e. L1/L2/L3 misses. 
 
 Patterns:
-Pattern is the data that is written to memory by the exerciser for performing the memory 
-ops.Rule paramemter “PATTERN_ID” specifies the pattern being used. One can specify pattern 
-in following ways:
--	Through pattern file
--	Special patterns like RANDOM and ADDRESS
--	Through upto 32 byte hexadecimal immediate pattern
+Pattern is the data which is written to memory by the exerciser for performing the memory ops. 
+Rule parameter PATTERN_ID specifies the pattern being used. One can specify pattern in following ways:
+	-   Through pattern file
+	-   Special patterns like RANDOM and ADDRESS
+	-   Through upto 32 byte hexadecimal immediate pattern
 Exercise supports upto 9 different patterns for a given stanza.
 
-Memory exerciser performs memory ops and while performing data integrity check if it 
-encounters a miscompare the exerciser drops to kernel debugger to facilitate debugging 
-with certain interesting pointers in GPRs R3 through R9. 
--------------------------------------------------------------------------------------------
-TLBIE Test Case:
--------------------------------------------------------------------------------------------
-Purpose: This test case was designed to generate excessive tlbie's in the system. 
-tlbie stands for Translation LookAside Buffer Invalidate Entry.
-Feature: 541203 created a tlbie test case using hxemem64 exerciser. 
-To run tlbie test case alone use the mdt file "mdt.tlbie".
-
-The rules file used for tlbie test case is "tlbie", which look like following:
-    tblie test case...
-    rule_id = mem_tlb
-    num_oper = 100
-    oper = tlb
-    seg_size_4k = 1048576
-
-Only above mentioned keywords are supported for oper = tlb.
-Note: all messages in the /tmp/htxmsg will have keyword TLBIE to make tlbie test case 
-messages easily identifiable.
---------------------------------------------------------------------------------------------
-MPSS Test Case - AIX 610 and above
---------------------------------------------------------------------------------------------
-Purpose: MPSS [Mixed Page Size Segment] is supported on AIX 610 onwards that allows a 
-segment to contain a mix of both 4K and 64K pages. AIX supports PSPA (page size promotion 
-aggresion) to promote a page from 4K to 64K in a block of 16*4K pages. Conversion of 16*4K 
-pages to one 64K page depends on PSPA value. In MPSS test case a mixed page segment is 
-created from Uni page size segment by playing with PSPA. Once the segment is converted to 
-MPSS, WRC operation is performed with specified pattern such that the segment still remains 
-MPSS for a life of test case.There is a special rule file, maxmem.mpss, that runs MPSS 
-testcases. This test only uses MPSS segments as data segments and not text segments.
-
-Feature # 613978 was created to add MPSS support in hxemem64 exerciser.
-
-The valid rule file parameters for eMPSS test case are:
-
-      rule_id = mpss_0xf
-      num_oper = 2000
-      seg_size_4k = 268435456 [256MB]
-      crash_on_misc = no
-      debug_level = 0
-      width = 8
-      compare = yes
-      pattern_id = HEXFF(8)
-      max_mem = no
-
-      All the above keywords are supported for oper = mpss
-
---------------------------------------------------------------------------------------------
-eMPSS test case:
---------------------------------------------------------------------------------------------
-Purpose: eMPSS [ Enhanced 16MB mixed page segment support] is supported for AIX61J and above,
-that allows a segment to contain  mix of 4K, 64K and 16M pages.
-eMPSS rule stanzas are enabled in maxmem.empss and mem.empss.only rule files.
-To run the empss testcase, one has to select mdt.bu.empss or mdt.mem.empss Or could create a
-custom mdt file using one of these rule files. 
-
-eMPSS test case is supported on P7 DD1 (and later) HW running AIX61J and later.
-
-Valid rule file parameters for eMPSS test case are:
-rule_id = empss_1
-num_oper = 20
-remap_p = 10
-oper = empss
-sao_enable = 0
-d_side_test = 1
-i_side_test = 1 
-addnl_i_side_test = 1
-base_page_size = 4K
-
-Please refer rule file parameters section to know more details about these parameters.
-
--------------------------------------------------------------------------------------------
-nstride test case:
--------------------------------------------------------------------------------------------
-Purpose: To introduce a stride in the memory access pattern. The stride size for accessing the
-memory is defined through a rulefile parameter "stride_sz". By default, its value is 128 byte(cacheline). 
-The main intention of this testcase have more L1 misses.
-
-nstride stanza is enabled in rules.max_cache_miss rulefile. One need to select mdt.max_cache_miss to run
-nstride testcase.
-
-Below are the valid rule file paramteters for nstride testcase:
-rule_id = l2l3miss
-max_mem = yes
-mem_percent = 70
-compare = yes
-mode = concurrent
-oper = nstride
-stride_sz = 128
+Memory exerciser performs memory ops and while performing data integrity check if it
+encounters a miscompare the exerciser drops to kernel debugger to facilitate debugging
+with certain interesting pointers in GPRs, R3 through R9.
 
 
------------------------------------------------------------------------------------------------
- (8) rule file parameters:
----------------------------------------------------------------------------------------------
-This section describes various rule parameters and relevant details supported by hxemem64 
-exerciser.
+(8) Rule file parameters:
+-------------------------------
+Hxemem64 rule parameters can be classified in 2 sections: Global rules and Stanza specific rules. 
+Global rule parameters are generally placed at the top of the rule file i.e before first stanza and
+their naming convention is with prefix "global_". These rules are visible/accessible across and beyond all stanzas. 
 
-Sample Rule File:
----------------------------------------------------------------------------------------------
-* write out all zeros to memory...
-rule_id = mem_0xdb
-pattern_id = HXZEROS (8)
-mem_percent = 75
-max_mem = yes
-mode = concurrent
-num_threads = 2
-compare = yes
-crash_on_misc = yes
-num_oper = 1
-oper = mem
-seg_size_4k = 268435456
-seg_size_64k = 268435456
-seg_size_16m = 268435456
-seg_size_16g = 17179869184
-num_seg_4k = 1
-num_seg_64k = 1
-num_seg_16m = 1
-num_seg_16g = 1
-debug_level = 2
-width = 8
----------------------------------------------------------------------------------------------
+Description of Global rule parameters:
+==============================================================================================
+Name : global_alloc_mem_percent
+Description: Specifies the percentage of free memory to be allocated for exercising. Value can be specified in the range 1-99.  
+This value is applied only on base page pool i.e 4K and/or 64K. 
+In case of "chip memory view"  mode, the value is the percentage of free memory from every chip in the system. 
+Otherwise, the percentage is applied at system/partition level.
+
+Default: 70
+Syntax: Example, 
+global_alloc_mem_percent = 70
+
+Notes: Please use this parameter cautiously if you are using above 80% value. "global_alloc_mem_percent" rule 
+will be overwritten if "global_alloc_mem_size" global rule parameter is present.
+==============================================================================================
+Name: global_alloc_mem_size
+Description: Specifies the amount of memory in bytes to be allocated for exercising. 
+Value can be specified in the range from minimum segment size to max possible size of available free memory. 
+In case of "chip memory view" mode, the value is part of free memory from every chip in the system.
+Otherwise the mentioned memory size is considered at system level.
+Minimum segment size is dependent on rule parameter "global_alloc_segment_size".
+Default:  -1
+Syntax: Example, 
+global_alloc_mem_size  =  1073741824
+
+Notes: Please use this parameter cautiously if you are using above 80%  of total memory.
+"global_alloc_mem_size" rule will take priority on "global_alloc_mem_percent".
+==============================================================================================
+Name: global_alloc_segment_size
+Description: Specifies the standard size of each memory segment to be allocated in bytes for base page size pool (4K and/or 64K).
+The default segment size which is 256MB will be overwritten with it.
+Memory specified in rule "global_alloc_mem_size" or "global_alloc_mem_spercent" is divided in number of segments for exercising.
+Specified value must at least be equal to supported base page size(e.g: 64K)
+Default:  -1
+Syntax: Example, 
+global_alloc_segment_size = 536870912
+
+Notes: On Linux platform, the "global_alloc_segment_size" may get modified in exerciser code
+if specified value results in overshoot of Linux shm  parameters (shmmax/shmni). 
+============================================================================================
+Name: global_num_threads
+Description: Specifies the num of threads to create to allocate 
+memory specified by global_alloc_mem_percent" or "global_alloc_mem_size".
+This parameter is valid only in "system memory view" mode.
+
+Note: If "global_num_threads" is specified, then it is advised to specify "global_disable_cpu_bind = yes"
+as well for a stanza, so that cpu load is distributed as per OS scheduling policy, 
+Otherwise exerciser binds only to first  global_num_threads of available logical cpus. 
+
+Default:
+  global_num_threads = -1
+
+Name: global_debug_level
+Description: Debug level is at both global and stanza level, global level rule will handle print msgs 
+used in modules before first stanza test case commence,it decides on what level of messages to display. For example, if global_debug_level = 3
+it displays all messages i.e., important messages, info messages,debug messages and must print messages. 
+And if debug level = 1 has mentioned then the debug prints with level 1 and 0 will only be printed (i.e., only MUST and IMP messages).
+        Debug_level has 4 values:
+        0   (DBG_MUST_PRINT)
+        1   (DBG_IMP_PRINT)
+        2   (DBG_INFO_PRINT)
+        3   (DBG_DEBUG_PRINT)
+
+Notes: This is over written by stanza specific rule "debug_level", Only messages with debug level less than or
+equal to the stanza specified debug level are printed.
+Higher the debug level more the messages. Don't disturb debug level this is an aid for developer to debug the code issues.
+Default: 0
+Syntax: Example,
+         g_debug_level = 2
+==================================================================================================================
+Name: global_disable_cpu_bind
+Description: This parameter would disable the thread to bind to a particualr cpu for allocating memory. On enabling this parameter, 
+threads will be scheduled to run on cpus as per OS scheduling policies and 
+thus may not guarantee local memory affinity and performance of exerciser may get affected.
+
+Values Accepted:   YES or NO (YES to disable the binding, NO to enable the binding)
+Default: global_disable_cpu_bind  = no
+===================================================================================================================
+Name: global_startup_delay
+Description: This parameter specifies time laps after which the memory exerciser should start allocating memory segments during HTX run.
+Since the memory exerciser considers only the free memory on the system for testing, 
+it will wait till other HTX exercisers allocate their resources.
+The delay can be varied in between 0 to 120 seconds.
+Default: 90 seconds.
+Syntax: Example,
+global_startup_delay = 30
+====================================================================================================================
+Name: global_disable_filters
+Description: This parameter specifies whether to enable cpu and mem filters or not, 
+i.e exerciser should view/exercise memory at system level or at chip level. 
+
+Default : global_disable_filters = yes
+
+Notes: global_disable_filter is overwritten to no, if it finds partition is booted in dedicated processor mode and 
+Has good balance with cpu and mem configuration as explained in below table.
+-----------------------------------------------------------------------------------------------------------
+Chip no.       has cpu?     has mem? 		Hxemem64 runs in mode           comments
+-----------------------------------------------------------------------------------------------------------
+      1       	Y	      N   	  	System memory view	 	Filters disabled 
+      2         N             Y			System memory view		Filters disabled
+      3         Y             Y                 Chip memory view		Filters enabled ("global_disable_filters" overwritten to "no")
+      4         N             N                 Ignore				N.A.
+======================================================================================================================
+
+Description of Stanza specific rule parameters.
+------------------------------------------------------------
+
 Name: rule_id
-
-Purpose: Identification string of the rule
-Notes: It can contain only ascii characters, must be specified, and can be 1 to 8 characters 
-long.
+Description: Identification string of the rule.
+Notes: It can contain only ascii characters, must be specified, and can be 1 to 8 characters long.
 Default: No default value
-
 Syntax: For example,
          Rule_id = rule1
 ----------------------------------------------------------------------------------------------
 Name: pattern_id
 
-Purpose: Specifies the bit pattern to be used for performing memory ops.
- 
-Pattern_id could be specified in following ways: 
-1) Through a pattern file – Pattern data is read from a file with specified length.
+Description: Specifies the bit pattern to be used for performing memory ops.
+Pattern_id could be specified in following ways:
+1) Through a pattern file, Pattern data is read from a file with specified length.
 2) Through special keywords - RANDOM or ADDRESS
 ADDRESS pattern uses 8 byte effective address of a memory location as a pattern.
-For RANDOM pattern, exerciser generates 8 bytes pseudo random data with help of seed. During 
+For RANDOM pattern, exerciser generates 8/4/1 bytes pseudo random data with help of seed. During
 compare, same seed is used to regenerate the expected data.
-3) Through immediate hexadecimal no – One can specify up to 32 bytes of hexadecimal data to be 
-used as a pattern. 
+3) Through immediate hexadecimal number, One can specify up to 32 bytes of hexadecimal data to be
+used as a pattern.
 
 One can specify upto 9 different patterns using any of the above (1), (2) and (3).
 
-Note: When multiple patterns are specified in the same rule stanza, please refer 
+Note: When multiple patterns are specified in the same rule stanza, please refer
 SWITCH_PAT_PER_SEG rule parameter for details about how patterns are applied to segments.
 
-Usage: 
-	Through a pattern file:
-	Syntax:
-	PATTERN_ID = <name_of_the_pattern_file>(<pattern_size>)
-	e.g. PATTERN_ID = HEX55(4096)
-	where HEX55 is the pattern file name and pattern size is 4096. Pattern size amount of 
-	data is read from the file and replicated in the memory region.
-	Range: Pattern size must be a power of 2 and is ranging from 8 bytes to 4096 bytes. 
-	Possible values are 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096.
+Usage:
+    Through a pattern file:
+    Syntax:
+    PATTERN_ID = <name_of_the_pattern_file>(<pattern_size>)
+    e.g. PATTERN_ID = HEX55(4096)
+    where HEX55 is the pattern file name and pattern size is 4096. Pattern size amount of
+    data is read from the file and replicated in the memory region.
+    Range: Pattern size must be a power of 2 and is ranging from 8 bytes to 4096 bytes.
+    Possible values are 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096.
 
-	RANDOM or ADDRESS are special keywords. To use one of these, one can specify pattern_id 
-	as follows:
-	Eg: PATTERN_ID = RANDOM ADDRESS
-	These special patterns always use 8 byte as a pattern size.
-
-	Immediate hexadecimal pattern can be specified as:
-	Eg:
-	PATTERN_ID = 0x1010101010101010 
-	Pattern length must power of 2 and in the range of 8 to 32 bytes.
-
-	Multiple patterns can be specified using any of the above.
-	Eg:
-	PATTERN_ID = HEX55(4096) RANDOM HEXAA(32) ADDRESS 
-                              0xA1A2A3A4A5A6A7A8B1B2B3B4B5B6B7B8
+    RANDOM or ADDRESS are special keywords. To use one of these, one can specify pattern_id
+    as follows:
+    Eg: PATTERN_ID = RANDOM 
+    These special patterns always use 8 byte as a pattern size.
+     Immediate hexadecimal pattern can be specified as:
+    Eg:
+    PATTERN_ID = 0x1010101010101010
+    Pattern length must power of 2 and in the range of 8 to 32 bytes.
+    Multiple patterns can be specified using any of the above.
+    Eg:
+    PATTERN_ID = HEX55(4096) RANDOM HEXAA(32) ADDRESS
+                 0xA1A2A3A4A5A6A7A8B1B2B3B4B5B6B7B8
 ---------------------------------------------------------------------------------------------
- Name: max_mem
-Purpose: This parameter specifies whether to test % (as mentioned by MEM_PERCENT) of free mem
-OR test absolute amount of memory as mentioned in the rule file.
-
-Values Taken:
-If MAX_MEM is set to yes, exerciser tests MEM_PERCENT of available free memory from each page 
-pool.
-If MAX_MEM is set to no, exerciser tests the memory according to the values specified in rule 
-parameters NUM_SEG_XX and SEG_SIZE_XX. The amount of memory used for testing would be 
-(NUM_SEG_XX) * (SEG_SIZE_XX).
-When MAX_MEM is set to no, tt’s the responsibility of the user to set these rule parameters 
-such that exerciser does not fail due to insufficient memory.
-Note: Rule parameter SEG_SIZE_XX is considered for both max_mem = yes while NUM_SEG_XX is 
-considered only for max_mem = no case.
-
-Note: The value must be a YES or a NO.
-Default:YES
-
- Syntax: Example,
-         max_mem = yes
----------------------------------------------------------------------------------------------
-Name: compare
-Purpose: This parameter specifies whether to compare the contents of the shared memory buffers
-8 bytes at a time with the specified bit pattern.
-
- Notes: The value must be a YES or NO.
-
- Default: YES
-
- Syntax: Example,
-         compare = yes
-
- --------------------------------------------------------------------------------------------
 Name: crash_on_mis
 
-Purpose: This parameter specifies whether to trap to KDB or not in case of miscompares.
- 
-  Notes: The value must be "yes" or "no"
-
-  Default: "yes"
-
-  Syntax: Example,
+Description: This parameter specifies whether to trap to KDB or not in case of miscompares.
+Notes: The value must be "yes" or "no"
+Default: "yes"
+Syntax: Example,
           crash_on_mis = yes
-
 --------------------------------------------------------------------------------------------
- Name: num_oper
-
- Purpose: Specifies how many times to repeat the RWC operation. One operation is normally 1 
- Write , 1 read and 1 Compare. we can specify in one operation how many writes , read onlys 
+Name: num_oper
+ Description: Specifies how many times to repeat the RWR-C operation. One operation is normally 1
+ Write , 1 read and 1 Read-Compare. we can specify in one operation how many writes , read onlys
  and read_compares using the corresponding keywords num_writes, num_read_only, num_read_comp.
  For eg 1 operation can be 3 writes, 5 read_onlys and 3 read_compares.
-
  Notes: The value must be > 0.
-
  Default: 1
-
  Syntax: Example,
          num_oper = 1
-
 ---------------------------------------------------------------------------------------------
- Name: num_writes
+Name: num_writes
 
- Purpose:
- 	  Specifies the number of times to write in one operation.
- 	  One operation is normally 1 Write , 1 read and 1 Compare.
- 	  For more details refer num_oper parameter.
- 	  
-
- Notes: The value must be > 0.
+ Description:
+      Specifies the number of times to write in one operation.
+      One operation is normally 1 Write , 1 read and 1 Compare.
+      For more details refer num_oper parameter.
 
  Default: 1
 
@@ -348,200 +314,75 @@ Purpose: This parameter specifies whether to trap to KDB or not in case of misco
 ----------------------------------------------------------------------------------------------
  Name: num_read_only
 
- Purpose: Specifies number of times to perform a read in one operation. One operation is
+ Description: Specifies number of times to perform a read in one operation. One operation is
  normally 1 Write , 1 read and 1 Compare.
-
- Notes: The value must be > 0.
-
- Default: 1
-
+Default: 1
  Syntax: Example,
          num_read_only = 1
-
 --------------------------------------------------------------------------------------------
 Name: num_read_comp
-
- Purpose: Specifies how many times to do a read and compare (after writing) in one operation.
- Note: To use this we shouldn't make num_writes  = 0 it should be atleast 1 which is the 
+ Description: Specifies how many times to do a read and compare (after writing) in one operation.
+ Note: To use this we shouldn't make num_writes  = 0, it should be atleast 1 which is the
  default value of  num_writes.
  One operation is normally 1 Write ,1 read and 1 Compare.
-
- Notes: The value must be > 0.
-
  Default: 1
-
  Syntax: Example,
          num_read_comp = 1
-
----------------------------------------------------------------------------------------------
-Name: mode
-Purpose: Specifies the mode in which hxemem64 should run.
-
-There are two possible values for this parameter.
-mode = NORMAL
-Normal mode is a single threaded operation where in single thread performs write/read/compare 
-operation on every segment with specified patterns.
-
-mode = CONCURRENT	
-Concurrent mode is a multi threaded operation where in available shared memory segments are 
-divided equally among the threads and all the threads perform write/read/compare (WRC) 
-operation on allotted segments with specified patterns. Threads performing WRC operation bind 
-themselves to specific cpu depeding up on bind_proc and bind_method parameters.
-Exerciser attempts to grab local memory (node affinity) for each thread for better performance.
-Concurrent mode allows to drive high memory bandwidth across the system.
-When CONCURRENT mode is specified by default it spawns N number of threads where N 
-is number of logical processor or can be explicitly specified by  num_threads parameter.
-
- Notes: The value must be equal to NORMAL or CONCURRENT.
-
- Default: normal
-
- Syntax: Example,
-         mode = concurrent
 ---------------------------------------------------------------------------------------------
 Name: num_threads
 
-Purpose: Specifies the number of threads to spawn when mode is CONCURRENT. When MODE is NORMAL
-then it is always 1.
+Description:  This parameter is valid only in "system memory view" mode, which specifies the number of threads to spawn.
+The value must be >= 1 and <= Number of logical processors, If num_threads is specified more than the number of
+logical processors on the partition it is rounded off to number of logical processors.
 
-We can choose number of threads to be spawned when exerciser starts by specifying num_threads
-keyword. Mode should be CONCURRENT for enablement of this parameter.
-In case of mode is CONCURRENT and num_threads is not specified, then number number of logical
-cpu considered as number of threads by default.
-
-Notes: The value must be >= 1 and <= Number of logical processors If num_threads is specified 
-more than the number of logical processors on the partition it is rounded off to number of 
-logical processors.
-
+Note: If "num_threads" is specified, then it is advised to specify "disable_cpu_bind = yes" as well 
+for that stanza so that cpu load is distributed as per OS scheduling policy, 
+Otherwise exerciser binds only to first num_threads of available logical cpus. 
 Default:
-  If mode = concurrent, then it is equal to number of logical processor
-  If mode = normal , it will be made 1.
-
-Syntax: Example,
-	num_threads = 2
----------------------------------------------------------------------------------------------
-
-Name: bind_proc
-
-  Purpose: This parameter would enable the thread to bind to a particualr cpu for carrying out 
-  various operation.On disabling this parameter the threads will be scheduled to run on cpus as 
-  per OS scheduling policies.
-  
-  Values Accepted:    YES or NO (YES to make the binding , NO for no binding)
-
-  Default: bind_proc = yes
-----------------------------------------------------------------------------------------------
-
-Name:bind_method
-
-  Purpose: This parameter would allow the thread to bind to any cpu randomly for each write,
-  read and read-compare in one operation.This keyword is valid only for DMA and MEM operations.
-  If bind_proc is enabled this feature will be disabled.
- 
-Two values can be specified for this attribute. 
-Bind_method = YES
-If bind_method is enabled, for each write operation it binds with a random CPU then again it 
-binds with a random CPU for read-only  or read-compare operation.
-
-Bind_method = NO
-No random bind to cpu will happen during  each WRC.         
- Default: bind_method = NO
-	  
-----------------------------------------------------------------------------------------------
+  num_threads = -1
+-----------------------------------------------------------------------------------------
+Name: disable_cpu_bind
+Description: This parameter would enable the thread to bind to a particualr cpu for carrying out various operation.
+On enabling this parameter, the threads will be scheduled to run on cpus as per OS scheduling policies.  
+  Values Accepted:    YES or NO (YES to avoid binding, NO for enable binding)
+  Default: disable_cpu_bind = no
+-----------------------------------------------------------------------------------------
 Name: oper
-
- Purpose: Specifies the mode of operation for the threads to execute. 
- The various operations supported are DMA, MEM, TLB, RIM, MPSS and EMPSS
-
-For, Oper = MEM
-In this operation,  shared memory segment is filled from the host memory. 
-Entire segment is written prior to reading and compared based on the compare flag.
-
-For, Oper = DMA
-In this operation,  shared memory segment is filled from the by reading from the disk.
-Entire segment is written prior to reading and compared based on the compare flag.
-
-Oper =  RIM 
-In RIM operation, after every memory write, data is read back and compared based on compare flag.
-
-Oper = TLB
-TLB test case was designed to generate excessive tlbie's in the system. tlbie stands for 
-Translation LookAside Buffer Invalidate Entry.
-For more details on TLB see the TLB test case  section.
-
-Oper = MPSS
-Please see MPSS test case section.
-
-Oper = EMPSS
-Please see EMPSS test case section.
-
-Oper = NSTRIDE
-Please see NSTRIDE test case section.
-
-Notes: The value must be DMA or MEM or TLB or RIM or MPSS or EMPSS or NSTRIDE.
-
+Description: Specifies the mode of operation for the threads to execute. The various operations supported are DMA, MEM, RIM, STRIDE etc.
+Please see (7)DESCRIPTION section of  this document  for detailed explanation on individual operation.
+Notes: The value must be DMA or MEM or RIM or STRIDE.
  Default: MEM
-
  Syntax: Example,
         oper = mem
+-----------------------------------------------------------------------------------------
+Name: Name: seg_size_4k, seg_size_64k, seg_size_2m, seg_size_16m, seg_size_16g
+Description: Specify the size of the memory segment region in bytes which will be filled using
+the given page size. For eg: SEG_SIZE_64K = 2097152 , this will ask to exercise 2MB  memory from created shared memory segment (256MB by default)
+of 64K page size.
 
---------------------------------------------------------------------------------------------
- Name: seg_size_4k, seg_size_64k, seg_size_16m, seg_size_16g
-
- Purpose: Specify the size of the shared memory segments in bytes which will be filled using
- the given page size. For eg: SEG_SIZE_64K = 268435456 will create 256MB segment filled with 
- pages of  64K page size.
-
- Notes: The value must be >= 8 or <= 268435456 (for upto AIX 4.3.0) .
-        Please ensure that the segment size should be multiple of the page size.
-
- Default:
-      For 4K,64K and 16M page sizes default segment size = 256MB
-      For 16G page size default segment size is 16GB
+Notes:  1. The value must be >= page_size  or  <= 268435456 ( or less than if global_alloc_mem_size  is mentioned) .
+      	2. Please ensure that the segment size should be multiple of the page size.
+Default:
+      For 4K,64K page sizes, the default segment size  is  equal to 256MB
+      For huge/large pages, the page size itself is the default segment size(for eg: segment size = 2MB for 2MB page size)
 
  Syntax: Example,
          Seg_size_4k = 8192
+-----------------------------------------------------------------------------------------
+Name: width
+Description: Specify whether 1 byte, 4 byte or 8 byte load/store instructions will be used to fill
+the shared memory buffers on memory operations.
+Notes: The value must be 1, 4, or 8.
+This parameter is ignored for DMA write operations. Because  when written into the segment using
+the file operation (read) system call test case specifies the size of the pattern mentioned in rule.
 
----------------------------------------------------------------------------------------------
- Name: num_seg_4k, num_seg_64k, num_seg_16m, num_seg_16g
-
- Purpose: Specify the number of the shared memory segments to be creted for the given page size.
-
- Note:  In case of max_mem = no case, if the product of the number of segments and the segment
- size specified in the rules exceeds the real memory on the machine, the system may either 
- thrash (response to keyboard will be very slow) or run out of paging space
- (htx will terminate with signal 33).
-
- Default: 0
-
- Syntax: Example,
-         Num_seg_4k = 2
-
----------------------------------------------------------------------------------------------
- Name: width
-
- Purpose: Specify whether 1 byte, 4 byte or 8 byte store instructions will be used to fill 
- the shared memory  buffers on MEM operations.
-
- Notes: The value must be 1, 4, or 8.
-
-  This parameter is ignored for DMA write operations. Because as we write into the segment using 
-  the file operation (read) system call which doesn't specify the size of the read into the 
-  segment buffer.
-
- Default: 8
-
+Default: 8
  Syntax: Example,
          width = 8
-
-----------------------------------------------------------------------------------------------
- Name: debug_level
-
- Purpose: Debug level decides on what level of messages to display. For example if 
- debug_level = 3 it display all messages i.e., important messages, info messages, debug 
- messages and must print messages.And if you give debug level = 1 then the debug prints 
- of level 1 and 0 are only printed i.e., only MUST and IMP messages are printed.
-          Debug_level has 4 values:
+-----------------------------------------------------------------------------------------
+Name: debug_level
+ Description: Debug level decides on what level of messages to display. 
+        Debug_level has 4 values:
         0   (DBG_MUST_PRINT)
         1   (DBG_IMP_PRINT)
         2   (DBG_INFO_PRINT)
@@ -549,431 +390,231 @@ Notes: The value must be DMA or MEM or TLB or RIM or MPSS or EMPSS or NSTRIDE.
 
  Notes:    Only messages with debug level less than or equal to the stanza specified debug level
  are printed. Higher the debug level more the messages.
-
  Default: 0
-
  Syntax: Example,
          debug_level = 2
 
- Note: Don’t disturb debug level this is an aid for developer to debug the code issues.
-
+ Note: Do not disturb debug level, as this is an aid for developer to debug the code issues.
 ----------------------------------------------------------------------------------------------
- Name: mem_percent
+Name: mem_percent
 
- Purpose: Specifies the percent of free memory to be used for testing. We can specify a range 
- from 20-99.
-
- Notes: Please use this parameter cautiously if you are using above 80% value. This key word is
- only considered in MAX_MEM = YES case.
-
- Default: 70
-
+Description: This parameter is valid only in "system memory view" mode, Specifies the 
+percentage of memory to be used for exercising from allocated memory using
+global_alloc_mem_percent or global_alloc_mem_size. We can specify a range from 1-100.
+Default: 100
  Syntax: Example,
-         Mem_percent = 80
-
----------------------------------------------------------------------------------------------
-Other parameters behavior for max_mem = YES case :
-
-This case lets the exerciser use mem_percent of free memory for testing.
-For example if mem_percent = 75. The exerciser creates that many number
-of segments (of specified size) such as to fill 75% of free memory.
-So in max_mem = yes case num_seg_x is inactive (num_seg_x value is
-not considered).
-
-----------------------------------------
-PARAMETER   		STATE
-
----------------- -----------------------
-compare     		Active
-num_oper   		Active
-seg_size_4k    		Active
-seg_size_64k    	Active
-seg_size_16m   		Active
-seg_size_16g    	Active
-
-num_seg_4k  		InActive
-num_seg_64k 		InActive
-num_seg_16m 		InActive
-num_seg_16g 		InActive
-
-debug_level 		Active
-mem_percent 		Active
-width       		Active
-
----------------------------------------------------------------------------------------------
-Parameter behavior for max_mem = no case :
-
-In this case exerciser creates the specified number of segments
-of the specified size as mentioned in the rules.
-
-So please use this max_mem=no with proper num_seg_x and seg_size_x parameters
-This case assumes that user knows the present memory configuration of the system.
-------------------------------------
-PARAMETER   		STATE
----------------- -------------------
-compare     		Active
-num_oper    		Active
-seg_size_4k     	Active
-seg_size_64k    	Active
-seg_size_16m   		Active
-seg_size_16g  	  	Active
-num_seg_4k  		Active
-num_seg_64k 		Active
-num_seg_16m 		Active
-num_seg_16g 		Active
-debug_level 		Active
-mem_percent 		Active
-width       		Active
-
-As you can see num_seg_x are Active in max_mem = no case.
-
-
-EMPSS TEST CASE PAREMETERS:
+         mem_percent = 80
 ----------------------------------------------------------------------------------------------
-Name : remap_p
+Name: cpu_percent
+Description: This parameter is valid only in "system memory view mode", 
+Specifies the percent of logical cpus present in system(or % of  global_num_threads value). 
 
-Purpose: To specify the number of operations in percentage after which the segments are 
-remapped during execution of empss testcase. 
-
-Notes:   This parameter is valid only for empss test case for which the rule file used is 
-maxmem.empss or mem.empss.only.
-
- Default: None
-
- Syntax: Example,
-         remap_p = 10
-
----------------------------------------------------------------------------------------------
-Name: sao_enabled
-
-Purpose: To specify whether to make memory use sao (strong access ordering).This is enabled 
-only for  empss test case.
-Notes: This parameter is only valid for empss test case. It can have value either "0" or "1".
-Default: 0
-
-Syntax: Example,
-	Sao_enabled = 0
-
+Note: If "cpu_percent" is specified, then it is advised to specify "disable_cpu_bind = yes" as well 
+for same stanza, so that cpu load is distributed as per OS scheduling policy, 
+Otherwise exerciser binds only to first  % of available logical cpus. 
 ----------------------------------------------------------------------------------------------
-
-Name: i_side_test
-
-Purpose: To specify whether to enable i-side testing for empss test case.
-
-Notes: This parameter is only valid for empss test case. It can have value wither “0” or “1”.
-
-Default: 0
-
-Syntax: Example,
-	i_side_test = 1
-
-----------------------------------------------------------------------------------------------
-Name: d_side_test
-Purpose: To specify whether to enable d-side testing for empss test case.
-
-Notes: This parameter is only valid for empss test case. It can have value either “0” or “1”.
-
-Default: 0
-
-Syntax: Example,
-	d_side_test = 0
-
-----------------------------------------------------------------------------------------------
-
-Name: addnl_i_side_test
-
-Purpose: To specify whether to make enable addnl_i_side testing for empss test case.
-
-Notes: This parameter is only valid for empss test case. It can have value either “0” or “1”.
-
-Default: 0
-
-Syntax: Example,
-	addnl_i_side_test = 1
-
-----------------------------------------------------------------------------------------------
-
-Name: base_pg_sz
-
-Purpose: To specify the minimum page size for all the segments in empss testcase.
-
-Notes: This parameter is only used for empss test case. Only 4K and 64K are the valid values 
-for this.
-
-Default: 4K
-
-Syntax: Example,
-	base_pg_sz = 4K
-
-----------------------------------------------------------------------------------------------
-Name: base_sg_sz
-
-Purpose: To specify the minimum segment size to use for empss testing.
-
-Notes: This parameter is only valid for empss test case. Only 256MB and 1TB are the valid 
-values for it.
-
-Default: 256MB
-
-Syntax: Example,
-	base_sg_sz = 1TB
-
-----------------------------------------------------------------------------------------------
-Name :startup_delay
-
-Purpose: This parameter specifies time laps after which the memory exerciser should  start 
-allocating memory segments during HTX run .Since the memory exerciser considers only  the free
-memory on the system for testing, it will wait till the other HTX exercisers allocate thier
-resources.The delay can be varied in between 0 to 120 seconds.
-
-Default: 90 seconds.
-
-Syntax: Example,
-startup_delay = 30
-----------------------------------------------------------------------------------------------
-Name: messages
-
-Purpose:This parameter specifies whether to print debug messages during the memory exerciser
-run.
-possible values YES or NO.
-
-Default:YES
-
-Syntax: Example,
-messages = yes
-----------------------------------------------------------------------------------------------
-
 Name: switch_pat_per_seg
-This parameter specifies whether to use all the patterns on each memory segment or to use 
+This parameter specifies whether to use all the patterns on each memory segment or to use
 specified pattern on each memory segment.
-This is valid for OPER = MEM and OPER = RIM
+This is valid for OPER = MEM and OPER = RIM or OPER = STRIDE
 
 There are three possible values for this parameter as below.
 SWITCH_PAT_PER_SEG = ALL
-If ALL is selected all the patterns are tested on each memory segment. 
+If ALL is selected all the patterns are tested on each memory segment.
 
 SWITCH_PAT_PER_SEG = YES
- If yes is selected, it makes sure to use a particular pattern for each memory segment.Here
- pattern would be switched for each segment.
+ If yes is selected, it makes sure to use a particular pattern for each memory segment. Here
+ pattern will be switched for each segment.
 
 SWITCH_PAT_PER_SEG = NO
 Fixed pattern would be used for all segments.
 Refer pattern_id section for more details.
 ----------------------------------------------------------------------------------------------
-
 Name: stride_sz
-Purpose: This parameter specifies the stride size. This is valid only for nstride testcase.
+Description: This parameter specifies the stride size. This is valid only for stride testcase.
 
 Default: 128
 
 Syntax: Example
 stride_sz=128
 ----------------------------------------------------------------------------------------------
+NAME: affinity
+Description: This parameter is valid only in "chip memory view" mode(global_disable_fiters=no),
+specifies relationship between cpu and memory based on cpu_filter and mem_filter. Supported values are 
+LOCAL,REMOTE_CHIP,REMOTE_NODE, FLOATING, RANDOM.
 
-(9) Miscompare Analysis:
-------------------------
+LOCAL: Memory from  a chip is exercised by binding to cpus from same chip. 
+REMOTE_CHIP: Memory from a chip is exercised by binding to cpus from next chip's cpus in a round robin fashion.
+REMOTE_NODE: Memory from a chip is exercised by binding to cpus from  chip belongs to next node.
+FLOATING: Memory from a chip is exercised without binding to any specific cpus. 
+RANDOM: Memory from a chip is exercised by binding to random selected cpus  from whole system.
+
+NOTE:  REMOTE_NODE and RANDOM are not supported currently. 
+Default: LOCAL
+Syntax: Example
+affinity = LOCAL
+----------------------------------------------------------------------------------------------
+NAME:cpu_filter
+Description: This parameter is valid only in "chip memory view mode"(global_disable_fiters=no),
+Specifies usage of cpus in system hierarchy manner i.e  node->chip->core->cpu. And decides number of threads to be created for
+an operation.
+
+Format: N<tok>P<tok>C<tok>T<tok>
+<tok> can be one of    *, single absolute numbers, range (format: [num1-num2]), multiple absolute numbers (format:[num1,num2,num5]), mix of
+range and absolute numbers (format:[num1-num3,num6]), percentage (format: %num or [%num]).
+Multiple filters (upto to 8) can be specified with space as a separation delimiter.  
+A single effective filter mask will be derived by exerciser from all specified cpu filters.
+
+Default: cpu_filter =  N*P*C*T*
+
+Valid cpu filter Examples with description :
+1.	N*P*C*T*	 : Enable use of all available cpus in the system.
+2.	N*P*C*T0 	 : Enable use of only thread 0 from every core in the system.
+3.	N0P0C0T0	 : Single thread operation, uses  cpu 0  to bind and run, cpu 0 is 0th cpu of Node0, chip0,core0.
+4.	N*P*C[0,5-7]T*  or N*P*C0T*  N*P*C[5-7]T*	or	N*P*C[0,5,6,7]T*       
+			   Use all cpus  only  from cores 0,5,6,7 of all chips in the system to bind and run.
+5.	N*P%50C*T*	 : Use  cpus of  first 50%  chips from every node. 
+
+Below are some examples of invalid format of cpu_filter, Exerciser behavior is unexpected in such cases.  
+1.	NPCT*		 :  entry at every node.chip,core,thread level must have a valid <tok> as explained above. 
+2.	N*P*C%50 	 :  specified filter must have all four entries N,P,C and T.
+3.	N*P*C*T50%       :  correct usage is  N*P*C*T%50
+4.	N*P*C*T0-3 	 :  When range is specified, it must be in "[ ]",correct usage is N*P*C*T[0-3].
+5.	N*P*C0,3T*	 :  correct usage is N*P*C[0,3]T* or  "N*P*C0T*  N*P*C3T*" or "N*P*C[0]*T* N*P*C[3]*T*"
+6.	N*P*C*T[]        :  [ ] cannot be empty.
+
+Note: 	1. Numbers that represent NPCT are always logically contiguous. 
+	2. When absolute numbers are specified in cpu_filter, User must make sure that numbers are within 
+	   boundaries of node, chip, core and, thread on that system.
+----------------------------------------------------------------------------------------------
+Name : mem_filter
+Description: This parameter is valid only in chip memory view mode(global_disable_fiters=no),
+Specifies usage of memory per page_size pool, in system hierarchy manner node->chip.
+
+Format: N<tok1>P<tok1>[<page_size1>_<tok2>, <page_size2>_<tok2>]
+tok1 	   :It can be any of  *, single absolute numbers. 
+page_size  :4K,64K,2M and/or 16M  (both case 'k' or 'K','m' or 'M'  supported in mem_filter).  
+	    Page sizes, which do not support for a given system are ignored by exerciser and 
+	    continues exercising mem by considering only supported and filter mentioned page size pools. 
+
+tok2	   :can be any of  %, absolute value with suffix MB or GB, number of pages with suffix #. For base page size (i.e 4k and/or 64K) 
+       	    this filter value is applied on allocated memory for that chip as per global rules global_alloc_mem_percent or global_alloc_mem_size.
+       	    And for huge page size (i.e 2M or 16M) the filter value is applied on free memory backed with huge page size.
+
+Multiple filters (upto to 8) can be specified with space as a separation delimiter.  
+A single effective filter mask will be derived by exerciser from all specified mem filters.
+
+Default: mem_filter = N*P*[4K_100%,64K_100%,2M_100%,16M_100%]
+
+Valid mem_filter examples 
+1.N*P*[4K_50%,64K_50%,2M_#20,16M_#20]		        :  50% memory from 4K and/or 64K page pool  and 20 huge pages from 2M or 16M page pool  is exercised. 
+2.N0P0[2M_100%,16M_100%]  N0P1[2M_100%,16M_100%]   :  All supported  huge pages(2M or 16M) are exercised from first 2 chips of node 0. 
+3.N0P0[4K_512MB,64K_512MB]  N1P1[4K_1GB,64K_1GB]  
+
+
+Invalid or not supported mem_filter format examples, Exerciser behavior is unexpected in such cases.  
+1.N*P*[4K_50%,4K_1GB]	: same page size for a chip cannot be repeated in a filter or by using multiple filters. 
+2.N*p*[64K_1024KB]	: KB  or TB or Bytes is not supported.
+3.N0P[0-2][16M_100%]	: range or % supported at chip level is not supported, usage of multiple filters is the alternative. 
+4.NP*[4K_100%,64K_100%] : N<tok> is missing.
+
+
+Note: 	1. Numbers that represent NP are always logically contiguous. 
+	2. When absolute numbers are specified with NP in mem_filter , 
+	   User must make sure that numbers are within  boundaries of node, chip on that system.
+	3. When absolute sizes are specified with page_sizes (i.e MB, GB or #), User must make sure that the size should be less than the available free memory and
+	   also, less than the allocated memory using global_alloc_mem_percent.
+
+==================================================================================================================
+
+(9) filters and affinity relation.
+-------------------------------------------
+User must specify filters accordingly, such that it should full fill the affinity requirement.  For default values of cpu_filter and mem_filter,
+exerciser internally takes care of affinity by overwriting current affinity or by ignoring imbalanced chip.
+
+Some invalid combination examples:
+      1.affinity = local
+	cpu_filter = N0P0C*T*
+	mem_filter = N0P1[64K_100%,16M_100%]
+
+      2.affinity = remote_chip
+	cpu_filter = N0P0C*T*	  
+	mem_filter = N0P0[64K_100%,16M_100%]
+
+(10) Miscompare Analysis,
+--------------------------------------------------------
 For AIX miscompare registers are interpreted as:
  gpr3 = 0xFFFFFFFFBEAFDEAD.
  gpr4 = Miscompare offset in number of dwords/words/bytes offset from starting address of
- the segment
- gpr5 = Address of Starting Address of the Segment Buffer
- gpr6 = Address of the Pattern buffer 
- gpr7 = Address of the miscomparing location in the segment buffer
+ the segment.
+ gpr5 = Starting Address of the Segment Buffer.
+ gpr6 = Address of the Pattern buffer. 
+ gpr7 = Address of the miscomparing location in the segment buffer.
  gpr8 = Structure which has dwords consecutively of
-    a) seg_number,b) page_size_index(0=4k,1=64k,2=16M,3=16G page size),
-    c) width(read/write) and d) the segment size, but only in case OPER = MPSS , 
-       it contains starting address of 4K page where miscompare has occurred .
- gpr9 = Current executing stanza pointer.
+    a) oper  b)seg_number,   
+    c) page_size_index(0=4k,1=64k,2=2M,3=16M,4=16G page size),
+    d) width(8/4/1)     e) the segment size     f) owning_thread
+    g) cpu_owning_chip    h) mem_owning_chip   
+    i) affinity_index (1=LOCAL,2=REMOTE_CHIP,3=FLOATING,4=INTRA_NODE,5=INTER_NODE,6=ABOSOLUTE)
+    j) Address of owning thread structure. 	
+    k) Address of  global structure "g_data".
+    l) sub segment number in case of 16G and RIM test case.
+    m)  sub segment size in case of 16G and RIM test case.
+    n) Total load/store access for this segment. 
+gpr9 = Current rule stanza pointer. 
+----------------------------------------------------------------------------------------
 
- Example of aix htx hxemem64 trap:
- -------------------------------------------
- # Static breakpoint:
- 000000010000BFBC       tweq    stkp,stkp           stkp=00000001100493F0
- 000000010000BFC0        xor    r3,r3,r3            r3=FFFFFFFFBEAFDEAD
- KDB(1)> dr
- r0  : 0000000010000000  r1  : 00000001100493F0  r2  : 0000000110005650
- r3  : FFFFFFFFBEAFDEAD  r4  : 0000000000000002  r5  : 0700000030000000
- r6  : 000000011000A278  r7  : 0700000030000004  r8  : 0000000110049490
- r9  : 0000000110008120  r10 : 0000000110005400  r11 : 0000000000000000
- r12 : 00000001000076A8  r13 : 0000000110051800  r14 : 0000000000000003
- r15 : 0000000002000000  r16 : 0000000110008120  r17 : 0000000000000000
- r18 : 0000000110015650  r19 : 0000000000000001  r20 : 0000000110008120
- r21 : 0000000110005A28  r22 : 0000000110015650  r23 : 0000000110015570
- r24 : 0000000000000000  r25 : 000000011000A270  r26 :  0000000000000000
- r27 : 0000000110005B40  r28 : 0000000000000000  r29 : 00000001100008C8
- r30 : 0000000000000001  r31 : 000000011000A278
- KDB(1)> dw @r6
- 000000011000A278: 00000000 00000000 20202020 20202020  ........
- KDB(1)> dw @r5
- 0700000030000000: 00000000 00000003 00000000 00000000  ................
- KDB(1)> dw @r7
- 0700000030000004: 00000003 00000000 00000000 00000000  ................
- KDB(1)> dw @r8 30
- 0000000110049490: 00000000 00000000 00000000 00000000  ................
- 00000001100494A0: 00000000 00000004 00000000 10000000  ................
- 00000001100494B0: 00000000 00000000 00000000 00000000  ................
- 00000001100494C0: 0FFFFFFF D0152F28 00000001 10015570  ....../(......Up
- 00000001100494D0: 00000000 00000000 00000000 00000000  ................
- 00000001100494E0: 00000001 10005128 00000000 00000000  ......Q(........
- 00000001100494F0: 00000001 10015570 00000001 10015650  ......Up......VP
- 0000000110049500: 00000001 10005C38 00000001 1000A278  ......\8.......x
- 0000000110049510: 00000001 10005B40 00000000 00000000  ......[@........
- 0000000110049520: 00000001 100008C8 00000001 1000A270  ...............p
- 0000000110049530: 00000001 100496D0 24000224 00000000  ........$..$....
- 0000000110049540: 00000001 00003C90 00000000 00000000  ......<.........
- KDB(1)> dw @r9 20
- 0000000110008120: 4D454D5F 30583030 00484558 5A45524F  MEM_0X00.HEXZERO
- 0000000110008130: 53000000 00000001 4D454D00 4E4F0000  S.......MEM.NO..
- 0000000110008140: 434F4E43 55525245 4E540000 00000000  CONCURRENT......
- 0000000110008150: 00000001 59455300 59455300 00000000  ....YES.YES.....
- 0000000110008160: 00000000 10000000 00000000 10000000  ................
- 0000000110008170: 00000000 10000000 00000004 00000000  ................
- 0000000110008180: 00000000 00000000 00000000 00000000  ................
- 0000000110008190: 00000004 00000000 00000046 59455300  ...........FYES.
-
-----------------------------------------------------------------------------------------------
- For Linux miscompare the registers are interpreted as:
- gpr3 = 0xBEEFDEADFFFFFFFF
- gpr4 = Starting Address of the Shared Memory Segment.
- gpr5 = Address of Miscomparing Location in the Shared memory segment.
- gpr6 = Bit pattern that was used in the 8 byte compare
- gpr7 = Size in bytes of Shared Memory Segment.
- gpr8 = Address of the Miscompare Error Message string.(This dumps in text all info)
-
- Process name which caused the trap to the kernel debugger would be
- hxemem64
-
- Example of htx linux hxemem64 miscompare trap:
-----------------------------------------------------------------------------------------------
- 2:mon> e
- cpu 0x2: Vector: ffffffffffffffd8  at [c00000003310b990]
-     pc: 0000000000000004
-     lr: c00000003310bb30
-     sp: c000000035977780
-    msr: 0
-   current = 0xc0000000340724c0
-   paca    = 0xc0000000004a3700
-     pid   = 4676, comm = hxemem64
- 2:mon> r
- R00 = c00000003310ba60   R16 = c00000003310bcd0
- R01 = c000000035977780   R17 = ffffffffffffffe9
- R02 = c0000000004e0498   R18 = c00000003310bcd0
- R03 = beefdeadffffffff   R19 = c00000003310bcd0
- R04 = 0000040000028000   R20 = c00000003310bae0
- R05 = 0000040000028000   R21 = c00000003412ca80
- R06 = 0000000000000000   R22 = c00000003310bcd0
- R07 = 0000000010000000   R23 = 0000000000000006
- R08 = 0000040021fb138c   R24 = c0000000004f68a0
- R09 = c00000000f6e1a60   R25 = c00000000f6e1a60
- R10 = c00000003310ba60   R26 = d0000000004ac480
- R11 = 8000000000009032   R27 = c000000000642340
- R12 = c00000003310ba70   R28 = c00000003310bb00
- R13 = 0000000000000000   R29 = 0000040021faf150
- R14 = c000000035c81000   R30 = c00000003310bb00
- R15 = ffffffffffffff9c   R31 = c000000000642340
- pc  = 0000000000000004
- lr  = c00000003310bb30
- msr = 0000000000000000   cr  = 00000001
- ctr = c000000035977780   xer = ffffffffffffff9c   trap = ffffffffffffffd8
- 2:mon> d 0000040021fb138c
- 0000040021fb138c 4d454d4f5259204d 4953434f4d504152  |MEMORY MISCOMPAR|
- 0000040021fb139c 45286878656d656d 36342920696e2072  |E(hxemem64) in r|
- 0000040021fb13ac 756c65204d454d5f 305830302c706173  |ule MEM_0X00,pas|
- 0000040021fb13bc 733d20312c52756c 65732066696c653d  |s= 1,Rules file=|
- 2:mon>
- 0000040021fb13cc 2f7573722f6c7070 2f6874782f72756c  |/usr/lpp/htx/rul|
- 0000040021fb13dc 65732f7265672f68 78656d656d36342f  |es/reg/hxemem64/|
- 0000040021fb13ec 6d61786d656d0a53 6861726564206d65  |maxmem.Shared me|
- 0000040021fb13fc 6d6f727920696428 73686d69645b305d  |mory id(shmid[0]|
- 2:mon>
- 0000040021fb140c 293d323638363938 352c536861726564  |)=2686985,Shared|
- 0000040021fb141c 206d656d6f727920 5365676d656e7420  | memory Segment |
- 0000040021fb142c 5374617274696e67 204541287368725f  |Starting EA(shr_|
- 0000040021fb143c 6d656d705b305d29 3d30783078343030  |memp[0])=0x0x400|
-2:mon>
- 0000040021fb144c 3030303238303030 2c0a4d6973636f6d  |00028000,.Miscom|
- 0000040021fb145c 70617265204f6666 73657420696e2074  |pare Offset in t|
- 0000040021fb146c 6865205368617265 64206d656d6f7279  |he Shared memory|
- 0000040021fb147c 207365676d656e74 2069732028302078  | segment is (0 x|
- 2:mon>
- 0000040021fb148c 2034292030206279 7465732066726f6d  | 4) 0 bytes from|
- 0000040021fb149c 2074686520737461 7274696e67206c6f  | the starting lo|
- 0000040021fb14ac 636174696f6e2c0a 4461746120657870  |cation,.Data exp|
- 0000040021fb14bc 6563746564203d20 3078300a44617461  |ected = 0x0.Data|
- 2:mon>
- 0000040021fb14cc 2072657472696576 6564203d20307833  | retrieved = 0x3|
- 0000040021fb14dc 3030303030303030 0a4d656d6f727920  |00000000.Memory |
- 0000040021fb14ec 4d6973636f6d7061 7265206c6f636174  |Miscompare locat|
- 0000040021fb14fc 696f6e204541203d 2030783078343030  |ion EA = 0x0x400|
- 2:mon>
- 0000040021fb150c 3030303238303030 200a536861726564  |00028000 .Shared|
- 0000040021fb151c 206d656d6f727920 7365676d656e7420  | memory segment |
- 0000040021fb152c 73697a65203d2032 3638343335343536  |size = 268435456|
- 0000040021fb153c 200a536861726564 206d656d6f727920  | .Shared memory |
- 2:mon>
- 0000040021fb154c 7365676d656e7420 636f6e7369737473  |segment consists|
- 0000040021fb155c 206f662070616765 73206f662073697a  | of pages of siz|
- 0000040021fb156c 65203d344b0a7265 61642f7772697465  |e =4K.read/write|
- 0000040021fb157c 207769647468203d 20342c2054726170  | width = 4, Trap|
- 2:mon>
- 0000040021fb158c 5f466c6167203d20 31205375622d5365  |_Flag = 1 Sub-Se|
- 0000040021fb159c 676d656e74204e75 6d6265723d302c20  |gment Number=0, |
- 0000040021fb15ac 5468726561643d30 2c6e756d5f6f665f  |Thread=0,num_of_|
- 0000040021fb15bc 746872656164733d 320a000000000000  |threads=2.......|
- 2:mon>
- 0000040021fb15cc 0000000000000000 0000000000000000  |................|
- 0000040021fb15dc 0000000000000000 0000000000000000  |................|
- 0000040021fb15ec 0000000000000000 0000000000000000  |................|
- 0000040021fb15fc 0000000000000000 0000000000000000  |................|
- 2:mon>
-
-----------------------------------------------------------------------------------------------
-
-(10) Exerciser specific log file:
+(11) Exerciser specific log file:
 -------------------------------------
-There is no exerciser specific log file created for hxemem64.
+echo $HTX_LOG_DIR
+/tmp/
 
- (11) Understanding htxstats:
+hxemem64 creates log file "$HTX_LOG_DIR/htx/hxemem64/mem/mem_segment_details" on test machine.
+
+#cat mem_segment_details | head
+
+******************************************************************************************************************************************************
+ In_use_seg_num  page_size      Owning_thread   cpu_num         mem_chip_num     segment_id              segment_size            segment_EA
+================================================================================================================================================
+        0        64K             0               1               0               1065686736              239140864               0x3fff55bf0000
+        1        64K             0               1               0               1065785043              239140864               0x3fff393d0000
+        2        64K             0               1               0               1065752274              239140864               0x3fff2afc0000
+        3        64K             0               1               0               1065719505              239140864               0x3fff477e0000
+        4        64K             1               9               0               1065817812              239140864               0x3fff6dbf0000
+
+ (12) Understanding htxstats:
 ----------------------------------
+Stats for hxemem64 mainly tells about the Bandwidth at the system/partition level 
+i.e number of bytes written/read per second to/from memory.
+
 hxemem64 stats appear as follows:
 
 mem:
-  cycles                              	=                  0
-  # good reads                        	=                  0
-  # bytes read                        	=        21118205952
-  # good writes                       	=                  0
-  # total instructions                	=                  0
-  # bytes written                     	=        21118205952
-  # good others                       	=                  0
-  # bad others                        	=                  0
-  # bad reads                         	=                  0
-  # bad writes                        	=                  0
-  # data transfer rate(bytes_wrtn/s)  	=        30298718.00
-  # data transfer rate(bytes_read/s)  	=        30298718.00
-  # instruction throughput(MIPS)     =           0.000000
+  cycles                              =                  1
+  # good reads                        =                  0
+  # bytes read                        =   3394396137521152
+  # good writes                       =                  0
+  # total instructions                =                  0
+  # bytes written                     =   1697242173014016
+  # good others                       =                  0
+  # bad others                        =                  0
+  # bad reads                         =                  0
+  # bad writes                        =                  0
+  # data transfer rate(bytes_wrtn/s)  =        10682474496.00
+  # data transfer rate(bytes_read/s)  =        21364391936.00
+  # instruction throughput(MIPS)      =           0.000000
 
-Stats for hxemem64 mainly tells about the number of bytes written/read per second to/from
-memory .
 
-(12) Limitations:
+(13) Limitations:
 ---------------------
-When a memory test fails i.e. when the exercise determines that the final result of a test rule 
-is not as  expected, it is up to the hardware engineers to determine the exact cause and 
-location of error with ESP or some other means. In other words, while the exerciser will be 
-helpful is stress testing the memory subsystem in a  multitasking environment, it will not be
-able to provide low level  details/diagnostics about the  failure. It can only tell which tests 
-have failed.
+When a memory test fails i.e. when the exerciser determines that the result of a test rule 
+is not as expected, it is up to the hardware engineers to determine the exact cause and 
+location of error with FSP or some other means. In other words, while the exerciser will be 
+helpful is stress testing the memory subsystem in a multitasking environment, it will not be
+able to provide low level details/diagnostics about the failure. It can only tell which tests 
+have failed and some high level cpu information.
 
 Software Notes:
 We obtain and exercise shared memory instead of the memory from the heap. This is due to the 
-fact that in case of shared  memory atlest upto 2 GB (except AIX 4.3.0) of memory can be 
-obtained where as in the latter case,malloc() gets memory from the private data area of the 
-process which will be much lesser.
-
-(13).DEPENDENCIES:
---------------------------
-System should have enough paging space as per the AIX Performance tuning guidelines for normal 
-operation.
-
-
-
+fact that in case of shared memory at least up to 2 GB of memory can be obtained where as in the
+latter case, malloc() gets memory from the private data area of the process which will be much lesser.

--- a/rules/reg/hxemem64/rules.app_server
+++ b/rules/reg/hxemem64/rules.app_server
@@ -1,3 +1,17 @@
+* IBM_PROLOG_BEGIN_TAG 
+* This is an automatically generated prolog. 
+*  
+* htx72F src/htx/usr/lpp/htx/rules/reg/hxemem64/rules.app_server 1.1 
+*  
+* Licensed Materials - Property of IBM 
+*  
+* COPYRIGHT International Business Machines Corp. 2010 
+* All Rights Reserved 
+*  
+* US Government Users Restricted Rights - Use, duplication or 
+* disclosure restricted by GSA ADP Schedule Contract with IBM Corp. 
+*  
+* IBM_PROLOG_END_TAG 
 * This rule files is primarily used by manufacturing
 * This combinations of patterns and associated iterations is able to stress
 * the memory for a minimum length of time, as required by manufacturing.
@@ -5,19 +19,21 @@
 * Memory that remains after the OS and other apps have allocated their's,
 * is used for the test.
 * In this case, 90 percent of remaining memory will be used up.
+****************************************************************
+*******Global Rules**********
+global_startup_delay = 90
+global_alloc_mem_percent = 90
+*********************************
 rule_id = MemTest
 pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA
-max_mem = yes
-mem_percent = 90
-compare = yes
 num_oper = 50
 num_writes = 1
 num_read_only = 0
 num_read_comp = 1
 switch_pat_per_seg = all
-mode = concurrent
-bind_proc = yes
 oper = mem
 width = 8
-startup_delay = 90 
-
+affinity = local
+disable_cpu_bind = NO
+cpu_filter = N*P*C*T*
+mem_filter = N*P*[4K_100%,64K_100%,2M_100%,16M_100%]

--- a/rules/reg/hxemem64/rules.comm_db_pk
+++ b/rules/reg/hxemem64/rules.comm_db_pk
@@ -1,3 +1,17 @@
+* IBM_PROLOG_BEGIN_TAG 
+* This is an automatically generated prolog. 
+*  
+* htx72F src/htx/usr/lpp/htx/rules/reg/hxemem64/rules.comm_db_pk 1.1 
+*  
+* Licensed Materials - Property of IBM 
+*  
+* COPYRIGHT International Business Machines Corp. 2010 
+* All Rights Reserved 
+*  
+* US Government Users Restricted Rights - Use, duplication or 
+* disclosure restricted by GSA ADP Schedule Contract with IBM Corp. 
+*  
+* IBM_PROLOG_END_TAG 
 * This rule files is primarily used by manufacturing
 * This combinations of patterns and associated iterations is able to stress
 * the memory for a minimum length of time, as required by manufacturing.
@@ -5,19 +19,21 @@
 * Memory that remains after the OS and other apps have allocated their's,
 * is used for the test.
 * In this case, 90 percent of remaining memory will be used up.
+*****************************************************************
+*******Global Rules**********
+global_startup_delay = 90
+global_alloc_mem_percent = 95
+*********************************
 rule_id = MemTest
 pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA
-max_mem = yes
-mem_percent = 95
-compare = yes
 num_oper = 500
 num_writes = 1
 num_read_only = 0
 num_read_comp = 1
 switch_pat_per_seg = all
-mode = concurrent
-bind_proc = yes
 oper = mem
 width = 8
-startup_delay = 90
-
+affinity = local
+disable_cpu_bind = NO
+cpu_filter = N*P*C*T*
+mem_filter = N*P*[4K_100%,64K_100%,2M_100%,16M_100%]

--- a/rules/reg/hxemem64/rules.dl1_reloads_from_caches
+++ b/rules/reg/hxemem64/rules.dl1_reloads_from_caches
@@ -1,42 +1,54 @@
-* @(#)11        1.1  src/htx/usr/lpp/htx/rules/reg/hxemem64/rules.dl1_reloads_from_caches, exer_cache, htxubuntu 2/22/11 06:18:03
+* IBM_PROLOG_BEGIN_TAG 
+* This is an automatically generated prolog. 
+*  
+* htx72F src/htx/usr/lpp/htx/rules/reg/hxemem64/rules.dl1_reloads_from_caches 1.1 
+*  
+* Licensed Materials - Property of IBM 
+*  
+* COPYRIGHT International Business Machines Corp. 2011 
+* All Rights Reserved 
+*  
+* US Government Users Restricted Rights - Use, duplication or 
+* disclosure restricted by GSA ADP Schedule Contract with IBM Corp. 
+*  
+* IBM_PROLOG_END_TAG 
+* %Z%%M%        %I%  %W% %G% %U%
 * This rule files is primarily used by manufacturing
 * This combinations of patterns and associated iterations is able to stress
 * the memory for a minimum length of time, as required by manufacturing.
-* Hxemem waits for 90 seconds before allocating any memory for the test.
-* Memory that remains after the OS and other apps have allocated their's,
-* is used for the test.
-* In this case, 90 percent of remaining memory will be used up.
+*************************************************************************
+*******Global Rules**********
+global_alloc_mem_percent  = 40
+global_alloc_huge_page = no
+global_startup_delay = 0
+global_disable_filters = no
+*********************************
 rule_id = 1 
 pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA 0xCCCCCCCCCCCCCCCC 0x3333333333333333 0x0F0F0F0F0F0F0F0F 0x3C3C3C3C3C3C3C3C 0x5A5A5A5A5A5A5A5A
-max_mem = no
-compare = yes
 num_oper = 10
 num_writes = 1
 num_read_only = 0
 num_read_comp = 1000
 switch_pat_per_seg = all
-mode = concurrent
-bind_proc = yes
 oper = mem
 width = 8
-num_seg_4k = 1
-seg_size_4k = 16384
-startup_delay = 0
+affinity = local
+disable_cpu_bind = NO
+cpu_filter = N*P*C*T*
+mem_filter = N*P*[64K_#128]
+seg_size_64k = 65536
 
 rule_id = 2 
 pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA 0xCCCCCCCCCCCCCCCC 0x3333333333333333 0x0F0F0F0F0F0F0F0F 0x3C3C3C3C3C3C3C3C 0x5A5A5A5A5A5A5A5A
-max_mem = no
-compare = yes
 num_oper = 10
 num_writes = 1
 num_read_only = 0
 num_read_comp = 1000
 switch_pat_per_seg = all
-mode = concurrent
-bind_proc = yes
 oper = mem
 width = 8
-num_seg_4k = 1
-seg_size_4k = 262144
-startup_delay = 0
+affinity = local
+cpu_filter = N*P*C*T*
+mem_filter = N*P*[64K_#256]
+seg_size_64k = 65536
 

--- a/rules/reg/hxemem64/rules.hpc_comp_node
+++ b/rules/reg/hxemem64/rules.hpc_comp_node
@@ -1,3 +1,17 @@
+* IBM_PROLOG_BEGIN_TAG 
+* This is an automatically generated prolog. 
+*  
+* htx72F src/htx/usr/lpp/htx/rules/reg/hxemem64/rules.hpc_comp_node 1.1 
+*  
+* Licensed Materials - Property of IBM 
+*  
+* COPYRIGHT International Business Machines Corp. 2010 
+* All Rights Reserved 
+*  
+* US Government Users Restricted Rights - Use, duplication or 
+* disclosure restricted by GSA ADP Schedule Contract with IBM Corp. 
+*  
+* IBM_PROLOG_END_TAG 
 * This rule files is primarily used by manufacturing
 * This combinations of patterns and associated iterations is able to stress
 * the memory for a minimum length of time, as required by manufacturing.
@@ -5,19 +19,21 @@
 * Memory that remains after the OS and other apps have allocated their's,
 * is used for the test.
 * In this case, 90 percent of remaining memory will be used up.
+************************************************************************
+*******Global Rules**********
+global_alloc_mem_percent = 99
+global_startup_delay = 90
+*********************************
 rule_id = MemTest
 pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA
-max_mem = yes
-mem_percent = 99
-compare = yes
 num_oper = 5
 num_writes = 1
 num_read_only = 0
 num_read_comp = 1
 switch_pat_per_seg = all
-mode = concurrent
-bind_proc = yes
 oper = mem
 width = 8
-startup_delay = 90
-
+affinity = local
+disable_cpu_bind = NO
+cpu_filter = N*P*C*T*
+mem_filter = N*P*[4K_100%,64K_100%,2M_100%,16M_100%]

--- a/rules/reg/hxemem64/rules.max_cache_hit
+++ b/rules/reg/hxemem64/rules.max_cache_hit
@@ -1,41 +1,39 @@
-* @(#)12        1.1  src/htx/usr/lpp/htx/rules/reg/hxemem64/rules.max_cache_hit, exer_cache, htxubuntu 2/22/11 06:18:05
-* This rule files is primarily used by manufacturing
-* This combinations of patterns and associated iterations is able to stress
-* the memory for a minimum length of time, as required by manufacturing.
-* Hxemem waits for 90 seconds before allocating any memory for the test.
-* Memory that remains after the OS and other apps have allocated their's,
-* is used for the test.
-* In this case, 90 percent of remaining memory will be used up.
-rule_id = l2_hit 
+* IBM_PROLOG_BEGIN_TAG 
+* It considers less memory as low as one 4k and 64K page per thread, accesses same
+* memory on next read opeartions to maximize cache hits
+****************************************************************
+*******Global Rules**********
+global_startup_delay = 0
+global_alloc_mem_percent = 30
+global_alloc_huge_page = no
+global_disable_filters = no
+*********************************
+rule_id = l2_hit
 pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA 0xCCCCCCCCCCCCCCCC 0x3333333333333333 0x0F0F0F0F0F0F0F0F 0x3C3C3C3C3C3C3C3C 0x5A5A5A5A5A5A5A5A
-max_mem = no
-compare = yes
 num_oper = 10
 num_writes = 1
 num_read_only = 0
 num_read_comp = 1000
 switch_pat_per_seg = all
-mode = concurrent
-bind_proc = yes
 oper = mem
 width = 8
-num_seg_4k = 1
+affinity = local
+disable_cpu_bind = NO
+cpu_filter = N*P*C*T%50
+mem_filter = N*P*[4K_#64,64K_#64]
 seg_size_4k = 4096
-startup_delay = 0
+seg_size_64k = 65536
 
-rule_id = l3_hit 
+rule_id = l3_hit
 pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA 0xCCCCCCCCCCCCCCCC 0x3333333333333333 0x0F0F0F0F0F0F0F0F 0x3C3C3C3C3C3C3C3C 0x5A5A5A5A5A5A5A5A
-max_mem = no
-compare = yes
 num_oper = 10
 num_writes = 1
 num_read_only = 0
 num_read_comp = 1000
 switch_pat_per_seg = all
-mode = concurrent
-bind_proc = yes
 oper = mem
 width = 8
-num_seg_4k = 1
-seg_size_4k = 262144
-startup_delay = 0
+cpu_filter = N*P*C*T*
+mem_filter = N*P*[4K_#128,64K_#128]
+seg_size_4k = 4096
+seg_size_64k = 65536

--- a/rules/reg/hxemem64/rules.max_cache_miss
+++ b/rules/reg/hxemem64/rules.max_cache_miss
@@ -1,25 +1,19 @@
-* @(#)13        1.2  src/htx/usr/lpp/htx/rules/reg/hxemem64/rules.max_cache_miss, exer_cache, htxubuntu 4/9/12 02:16:32
-* This rule files is primarily used by manufacturing
-* This combinations of patterns and associated iterations is able to stress
-* the memory for a minimum length of time, as required by manufacturing.
-* Hxemem waits for 90 seconds before allocating any memory for the test.
-* Memory that remains after the OS and other apps have allocated their's,
-* is used for the test.
-* In this case, 90 percent of remaining memory will be used up.
+* IBM_PROLOG_BEGIN_TAG 
+*******Global Rules**********
+global_alloc_mem_percent = 70
+global_startup_delay = 0
+*********************************
 rule_id = l2l3miss
 pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA 0xCCCCCCCCCCCCCCCC 0x3333333333333333 0x0F0F0F0F0F0F0F0F 0x3C3C3C3C3C3C3C3C 0x5A5A5A5A5A5A5A5A
-max_mem = yes
-mem_percent = 70
-compare = yes
 num_oper = 1
 num_writes = 1
 num_read_only = 1
 num_read_comp = 1
 switch_pat_per_seg = yes
-mode = concurrent
-bind_proc = yes
-oper = nstride
+oper = stride
 stride_sz = 128
 width = 8
-startup_delay = 0
-
+affinity = local
+disable_cpu_bind = NO
+cpu_filter = N*P*C*T*
+mem_filter = N*P*[4K_100%,64K_100%,2M_100%,16M_100%]

--- a/rules/reg/hxemem64/rules.web_server
+++ b/rules/reg/hxemem64/rules.web_server
@@ -1,3 +1,17 @@
+* IBM_PROLOG_BEGIN_TAG 
+* This is an automatically generated prolog. 
+*  
+* htx72F src/htx/usr/lpp/htx/rules/reg/hxemem64/rules.web_server 1.1 
+*  
+* Licensed Materials - Property of IBM 
+*  
+* COPYRIGHT International Business Machines Corp. 2010 
+* All Rights Reserved 
+*  
+* US Government Users Restricted Rights - Use, duplication or 
+* disclosure restricted by GSA ADP Schedule Contract with IBM Corp. 
+*  
+* IBM_PROLOG_END_TAG 
 * This rule files is primarily used by manufacturing
 * This combinations of patterns and associated iterations is able to stress
 * the memory for a minimum length of time, as required by manufacturing.
@@ -5,19 +19,22 @@
 * Memory that remains after the OS and other apps have allocated their's,
 * is used for the test.
 * In this case, 90 percent of remaining memory will be used up.
+*******Global Rules**********
+global_alloc_mem_percent = 30
+global_disable_cpu_bind  = NO
+global_startup_delay = 90
+*********************************
 rule_id = MemTest
 pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA
-max_mem = yes
-mem_percent = 30
 compare = yes
 num_oper = 5
 num_writes = 1
 num_read_only = 0
 num_read_comp = 1
 switch_pat_per_seg = all
-mode = concurrent
-bind_proc = yes
 oper = mem
 width = 8
-startup_delay = 90 
-
+affinity = local
+disable_cpu_bind = NO
+cpu_filter = N*P*C*T*
+mem_filter = N*P*[4K_100%,64K_100%,2M_100%,16M_100%]


### PR DESCRIPTION
Important Features in new revamped memory exerciser:
------------------------------------------------------
(1)Provides option to control memory workload for every supported page pool at each chip level.
(2)Provides option to control cpu workload at Node->Chip->Core->Threads level.
(3)Provides more run time for stress test, as mem allocation will be done only once.
(4) Improved performance. 

New rule files:
--------------------------------
(1)default : consumes 70% of memory, performs MEM,RIM,DMA and STRIDE operations.
(2)default.char: consumes 40% of memory, attempts to maximize DMI bandwidth with use of 50% threads per core.
(3)default.mfg and default.mfg.nodelay: consumes 90% of memory, Maximum coverage with increased stress.
(4)default.eq: equalizer specific rule file.