### PR TITLE
Fix SIGUNUSED as the signal is deprecated since glibc 2.26

### DIFF
--- a/bin/hxssup/build_ipc.c
+++ b/bin/hxssup/build_ipc.c
@@ -53,6 +53,12 @@
 /*
  * Define all other un-supported signals as SIGUNUSED
  */
+
+/* Defining SIGUNUSED if not, since deprecated with glibc >= 2.26*/
+#ifndef SIGUNUSED
+#define SIGUNUSED 31
+#endif
+
 #ifdef	__HTX_LINUX__
 #define	SIGMAX	(SIGRTMAX)
 #define	SIGEMT	(SIGSEGV)


### PR DESCRIPTION
If glibc version >= 2.26, SIGUNUSED is not available and hence
build fails with following.
build_ipc.c:59:17: error: ‘SIGUNUSED’ undeclared (first use in this function); did you mean ‘SI_USER’?
 #define SIGSYS (SIGUNUSED)
This patch fixes defines if it is not defined

Signed-off-by: Harish <harish@linux.vnet.ibm.com>