### PR TITLE
scripts/ver: Add "clear" as first argument to clear screen

### DIFF
--- a/etc/scripts/ver
+++ b/etc/scripts/ver
@@ -44,10 +44,10 @@
   SYS_FW_LEVEL=`cat /proc/device-tree/openprom/model | cut -d ',' -f2 2>/dev/null || echo "Not Found"`
 
 # Clear screen
-[ $# -lt 1 ] && tput clear
+  [ "$1" = "clear" ] && tput clear
 
 # Display the gathered information
-	                     echo "       ver 1.5.4.3 - OS, HTX, Firmware and Machine details"
+                         echo "               ver - OS, HTX, Firmware and Machine details"
                          echo
 
 [ "$OS" ]             && echo "                           OS: $OS"


### PR DESCRIPTION
Currently ver command clears screen by default before printing
OS and HW configutration details. This adds an extra over head
for user to scroll screen while using this command.

Change ver command behaviour to not clear screen by default.
Now it will clear screen only upon using "clear" as first argument.
Also remove versioning used with ver command in printed output.