### PR TITLE
Hybrid fabric links stress test support

### DIFF
--- a/bin/hxemem64/nest_framework.c
+++ b/bin/hxemem64/nest_framework.c
@@ -1,4 +1,3 @@
-/* IBM_PROLOG_BEGIN_TAG */
 /*
  * Copyright 2003,2016 IBM International Business Machines Corp.
  *
@@ -288,7 +287,8 @@ void get_test_type()
 	else if ((strncmp ((char*)(DEVICE_NAME+5),"cach",4)) == 0){
 		g_data.test_type = CACHE;
 	}
-	else if (	((strncmp ((char*)(DEVICE_NAME+5),"fabn",4)) == 0) || (strncmp ((char*)(DEVICE_NAME+5),"fabc",4)== 0)	){
+	else if (	((strncmp ((char*)(DEVICE_NAME+5),"fabn",4)) == 0) || (strncmp ((char*)(DEVICE_NAME+5),"fabc",4)== 0)	|| 
+		(strncmp ((char*)(DEVICE_NAME+5),"fabxo",5)== 0) ){
 		g_data.test_type = FABRICB;
 	}
 	else if ((strncmp ((char*)(DEVICE_NAME+5),"tlb",3)) == 0){
@@ -296,7 +296,7 @@ void get_test_type()
 	}	
 	else {
 		displaym(HTX_HE_HARD_ERROR,DBG_MUST_PRINT,"[%d]%s:unknown device name %s, supported htx nest devices are:"
-            "mem,cache<chip_num>,fabn,fabc,tlb\n",__LINE__,__FUNCTION__,DEVICE_NAME);
+            "mem,cache<chip_num>,fabn,fabc,fabxo,tlb\n",__LINE__,__FUNCTION__,DEVICE_NAME);
 		exit(1);
 	}
 		

--- a/bin/hxemem64/nest_framework.h
+++ b/bin/hxemem64/nest_framework.h
@@ -12,7 +12,11 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
  * implied.
-*/
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* IBM_PROLOG_END_TAG */
+
 /*
  * Debug messages levels (for displaying)
  * 0 (MUST DISPLAY MESSAGES), 1 (VERY IMPORTANT DISPLAY MESSAGES) ,
@@ -203,7 +207,7 @@ enum mem_oper_type { OPER_MEM=0,OPER_STRIDE, OPER_RIM, OPER_DMA, OPER_RAND_MEM, 
 enum caches	{ L1=0,L2,L3,L4 };
 enum cache_opers {NONE=0,OPER_CACHE,OPER_PREFETCH};
 enum cache_tests {CACHE_BOUNCE_ONLY=0,CACHE_BOUNCE_WITH_PREF,CACHE_ROLL_ONLY,CACHE_ROLL_WITH_PREF,PREFETCH_ONLY};
-enum affinity { LOCAL=1,REMOTE_CHIP,FLOATING,INTRA_NODE,INTER_NODE,ABOSOLUTE };
+enum affinity { LOCAL=1,REMOTE_CHIP,FLOATING,INTRA_NODE,INTER_NODE,ABOSOLUTE,ALL_FABRIC};
 enum pattern_size_type { PATTERN_SIZE_NORMAL=0, PATTERN_SIZE_BIG, PATTERN_ADDRESS, PATTERN_RANDOM,RANDOM_MEM_ACCESS };
 enum data_oper {WRITE=0,READ,COMPARE,RIM};
 enum width_oper {DWORD=0,WORD,BYTE};
@@ -569,6 +573,7 @@ struct dest_chip_details{
 struct fabb_exer_info {/* RFB1: keep a pointer of this strucure in global str*/
     unsigned long seg_size;
     long          fab_chip_L3_sz[MAX_CHIPS];
+	int 		  fab_cores[MAX_CHIPS][MAX_CORES_PER_CHIP];
     unsigned long segs_per_chip[MAX_CHIPS];
     struct dest_chip_details dest_chip[MAX_CPUS];
 

--- a/etc/scripts/devconfig
+++ b/etc/scripts/devconfig
@@ -410,32 +410,29 @@ fi
 #Append inter_node fabric link test stanza in mdt.bu_char
 
 if [ $true_pvr -ge 78 ]; then
-    if [[ $num_nodes -gt 1 ]]
-    then
-		echo                                                                                          | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-		echo "fabn:"                                                                                  | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-		echo -e "\tHE_name = \"hxefabricbus\"                     "                                   | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-		echo -e "\tadapt_desc = \"Node to Node\"                  "                                   | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-		echo -e "\tdevice_desc = \"Memory BW\"                    "                                   | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-		echo -e "\treg_rules = \"hxefabricbus/default.char\"        "                                 | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-		echo -e "\temc_rules = \"hxefabricbus/default.char\"        "                                 | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-		echo -e "\tcont_on_err = \"NO\"                         "                                     | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-		echo                                                                                          | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-    fi
-	 
-    if [[ -f ${HTXMDT}mdt.inter_chip ]]
-    then
-        echo                                                                                          | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-        echo "fabc:"                                                                                  | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-        echo -e "\tHE_name = \"hxefabricbus\"                     "                                   | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-        echo -e "\tadapt_desc = \"Chip to Chip\"                  "                                   | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-        echo -e "\tdevice_desc = \"Memory BW\"                    "                                   | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-        echo -e "\treg_rules = \"hxefabricbus/default.inter_chip\"        "                                 | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-        echo -e "\temc_rules = \"hxefabricbus/default.inter_chip\"        "                                 | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-        echo -e "\tcont_on_err = \"NO\"                         "                                     | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io > /dev/null
-        echo                            
+	cat ${HTXMDT}mdt.all | create_mdt_with_devices.awk > ${HTXMDT}mdt.fabric
+	if [ -f ${HTXMDT}mdt.inter_chip ] && [ -f ${HTXMDT}mdt.inter_node ];
+	then
+		fab_dev="fabxo:"
+		fab_rf="rules.all_links"
+	elif [ -f ${HTXMDT}mdt.inter_node ] && [ ! -f ${HTXMDT}mdt.inter_chip ];
+	then
+		fab_dev="fabn:"
+		fab_rf="default.inter_node"
+	elif [ ! -f ${HTXMDT}mdt.inter_node ] && [  -f ${HTXMDT}mdt.inter_chip ];
+	then
+		fab_dev="fabc:"
+		fab_rf="default.inter_chip"
 	fi
-
+	echo                                                                                          | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io  ${HTXMDT}/mdt.fabric > /dev/null
+		echo "$fab_dev"                                                                                  | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io ${HTXMDT}/mdt.fabric > /dev/null
+		echo -e "\tHE_name = \"hxefabricbus\"                     "                                   | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io ${HTXMDT}/mdt.fabric > /dev/null
+		echo -e "\tdevice_desc = \"Memory BW\"                    "                                   | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io ${HTXMDT}/mdt.fabric > /dev/null
+		echo -e "\treg_rules = \"hxefabricbus/$fab_rf\"        "                                 | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io ${HTXMDT}/mdt.fabric > /dev/null
+		echo -e "\temc_rules = \"hxefabricbus/$fab_rf\"        "                                 | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io ${HTXMDT}/mdt.fabric > /dev/null
+		echo -e "\tcont_on_err = \"NO\"                         "                                     | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io ${HTXMDT}/mdt.fabric > /dev/null
+		echo                                                                                          | tee -a ${HTXMDT}/mdt.bu_char ${HTXMDT}/mdt.nest.io ${HTXMDT}/mdt.inter_io ${HTXMDT}/mdt.fabric > /dev/null
+	 
     if [[ -f ${HTXMDT}/mdt.bw_bi ]];
     then
         cat ${HTXMDT}/mdt.bw_bi | create_mdt_without_devices.awk default >> ${HTXMDT}/mdt.inter_io

--- a/rules/reg/hxefabricbus/Makefile
+++ b/rules/reg/hxefabricbus/Makefile
@@ -3,6 +3,7 @@ TARGET = \
             hxefabricbus.readme \
             default.ab \
             default.xyz \
+            rules.all_links \
             default.inter_chip \
             default.inter_node
 

--- a/rules/reg/hxefabricbus/rules.all_links
+++ b/rules/reg/hxefabricbus/rules.all_links
@@ -1,0 +1,20 @@
+**Please read the documnetation hxefabricbus.readme_P9 for explaination of rule parameters.
+**************************************************************************************************
+*******Global Rules**********
+global_startup_delay = 0
+global_disable_cpu_bind  = NO
+global_disable_filters = no
+global_fabric_links_drive = cores
+*********************************
+rule_id = all_fab_links_test 
+oper = stride
+pattern_id = HEXFF(8) HEXZEROS(8) 0x5555555555555555 0xAAAAAAAAAAAAAAAA 0xCCCCCCCCCCCCCCCC 0x3333333333333333 0x0F0F0F0F0F0F0F0F 0x3C3C3C3C3C3C3C3C 0x5A5A5A5A5A5A5A5A
+switch_pat_per_seg = all
+num_oper = 5000
+num_writes = 1
+num_read_only = 1
+num_read_comp = 1
+width = 8
+affinity = intra_node
+disable_cpu_bind = NO
+cpu_filter = N*P*C*T*

--- a/rules/reg/hxemem64/rules.char_2
+++ b/rules/reg/hxemem64/rules.char_2
@@ -5,7 +5,9 @@
 ****************************************************************************************
 *******Global Rules**********
 global_startup_delay = 60
-global_alloc_mem_percent = 90
+global_alloc_mem_size = 1073741824
+global_alloc_segment_size = 10485760
+global_alloc_huge_page = no
 global_disable_cpu_bind  = NO
 global_disable_filters = no
 *********************************

--- a/setup/mem.setup
+++ b/setup/mem.setup
@@ -30,7 +30,7 @@ echo "mem.setup:OS proc_ver=$proc_ver, true pvr=$true_proc_ver" >> $HTXNoise
 
 ln -sf ${HTXBIN}/hxemem64_new ${HTXBIN}/hxetlbie
 ln -sf ${HTXBIN}/hxemem64_old ${HTXBIN}/hxecentaur
-ln -sf ${HTXBIN}/hxemem64_new ${HTXBIN}/hxefabricbus_new
+ln -sf ${HTXBIN}/hxemem64_new ${HTXBIN}/hxefabricbus
 if [ $true_proc_ver -lt 78 ];
 then
     #P8 or less
@@ -77,11 +77,9 @@ then
 	echo "mem.setup:Old mem and cache exer binaries will be used" >> $HTXNoise
 	ln -sf ${HTXBIN}/hxemem64_old ${HTXBIN}/hxemem64
     ln -sf ${HTXBIN}/hxecache_old ${HTXBIN}/hxecache
-	ln -sf ${HTXBIN}/hxefabricbus_old ${HTXBIN}/hxefabricbus
 else
 	ln -sf ${HTXBIN}/hxemem64_new ${HTXBIN}/hxemem64
     ln -sf ${HTXBIN}/hxecache_new ${HTXBIN}/hxecache
-	ln -sf ${HTXBIN}/hxefabricbus_new ${HTXBIN}/hxefabricbus
 fi
 Hugepagesize=`cat /proc/meminfo |grep Hugepagesize |awk '{print $2}'`
 if [[ $Hugepagesize -lt 2048 ]]


### PR DESCRIPTION
(1)Enabled simultaneous stress test algorithm for X and A link in fabricbus exer.
(2)Created new rule rule.all_links for fabric exer.
(3)Modified rules.char_2 to have memory allocation value in bytes.
(4)mdt.fabric creation based on system config.
