### PR TITLE
random_length_error

### DIFF
--- a/bin/hxestorage/hxestorage.c
+++ b/bin/hxestorage/hxestorage.c
@@ -1199,6 +1199,10 @@ int execute_validation_test (struct htx_data *htx_ds, struct thread_context *tct
          * know whether SEQ/RANDOM oper were going on.
          */
         tctx->cur_seek_type = RANDOM;
+        if (tctx->transfer_sz.increment == -1 && tctx->dlen != tctx->transfer_sz.min_len) {
+            tctx->dlen = tctx->transfer_sz.min_len;
+            tctx->num_blks = tctx->dlen / dev_info.blksize;
+        }
         oper_loop = 0;
         cur_num_oper = tctx->num_oper[RANDOM];
 


### PR DESCRIPTION
Write system call failure was happening due to  wrong xfer size and LBA no. generated by exerciser.
Error was happening when exerciser completed its SEQ. oper and started RANDOM ones. 
During the transition from SEQ. to RANDOM operations,we were generating a transfer length more
than the total blocks on the device. There was no proper check for it.
Fixed the code to check the length before starting random ops.
