### PR TITLE
hxeocapi_lib_path_inclusion

### DIFF
--- a/bin/hxeocapi/Makefile
+++ b/bin/hxeocapi/Makefile
@@ -9,7 +9,7 @@ OBJ_SUFF=.o
 CFLAGS += -O2 -g -D_GNU_SOURCE -D__HTX_LINUX__
 CFLAGS += -I/usr/local/include
 
-LIBS += -lhtx64 -lpthread -lrt -locxl
+LIBS += -lhtx64 -lpthread -lrt -locxl -Wl,-rpath=/usr/local/lib64/ 
 
 # Object files to build, of the form objname${OBJ_SUFF}
 OBJECTS = get_rule${OBJ_SUFF} hxeocapi${OBJ_SUFF} memcpy${OBJ_SUFF} 


### PR DESCRIPTION
openCAPI library path was missing in the Makefile. Added that as "-Wl,-rpath=/usr/local/lib64/"
