### PR TITLE
hung_io_design_change

### DIFF
--- a/bin/hxestorage/hxestorage.c
+++ b/bin/hxestorage/hxestorage.c
@@ -2021,7 +2021,7 @@ void update_blkno(struct htx_data *htx_ds, struct ruleinfo *ruleptr, struct thre
     /* DPRINT("num_blks_per_thread: %lld\n", num_blks_per_thread); */
     remaining_blks = (ruleptr->max_blkno.value[0] - ruleptr->min_blkno.value[0] + 1) % ruleptr->num_threads;
     for (th_num = 0; th_num < ruleptr->num_threads; th_num++, current_tctx++) {
-        current_tctx->min_blkno = th_num * num_blks_per_thread;
+        current_tctx->min_blkno = ruleptr->min_blkno.value[0] + th_num * num_blks_per_thread;
         current_tctx->max_blkno = current_tctx->min_blkno + num_blks_per_thread - 1;
         if (th_num == (ruleptr->num_threads - 1) && remaining_blks != 0) {
             current_tctx->max_blkno += remaining_blks;

--- a/bin/hxestorage/hxestorage_rf.c
+++ b/bin/hxestorage/hxestorage_rf.c
@@ -386,6 +386,9 @@ void check_n_update_rule_params(struct htx_data *htx_ds, struct ruleinfo *curren
     } else if (current_stanza_ptr->num_threads == DEFAULT_NUM_THREADS) {
         current_stanza_ptr->num_threads = 1;
     }
+    if(max_thread_cnt < current_stanza_ptr->num_threads){
+        max_thread_cnt = current_stanza_ptr->num_threads;
+    }
 }
 
 /*****************************************************************/

--- a/bin/hxestorage/hxestorage_utils.h
+++ b/bin/hxestorage/hxestorage_utils.h
@@ -140,14 +140,19 @@ extern int volatile collisions;
  * thread before performing any IO.
  */
 struct segment_table_data {
-        unsigned long long flba;        /* start LBA no. */
-        unsigned long long llba;        /* End LBA no. */
-        unsigned long long seg_flba;    /* start LBA no of individual segment. */
-        unsigned long long seg_llba;    /* End LBA no of individual segment. */
-        pthread_t tid;                  /* thread id */
-        time_t thread_time;             /* Time when IO started */
-        int hang_count;                 /* hang count */
-        int in_use;                     /* flag to indicate if segment index is in use */
+        unsigned long long th_context_addr; /* address of thread context updating the entry */
+        unsigned long long flba;            /* start LBA no. */
+        unsigned long long llba;            /* End LBA no. */
+        unsigned long long seg_flba;        /* start LBA no of individual segment. */
+        unsigned long long seg_llba;        /* End LBA no of individual segment. */
+        pthread_t tid;                      /* thread id */
+        time_t last_update_time;            /* Time when IO started */
+        time_t io_update_time[8];           /* Time stamp for individual IO operation */
+        pthread_mutex_t time_mutex;         /* Mutex lock for updating timestamp */
+        short time_index;                   /* index into io_update_time */
+        short hang_count;                   /* hang count */
+        int io_in_progress: 1;              /* Flag to check if IO is in progress */
+        int in_use: 1;                      /* flag to indicate if segment table entry is in use */
 };
 
 /* segment_table structure holds the uppper and lower lba range of individual segments */

--- a/bin/hxestorage/io_oper.h
+++ b/bin/hxestorage/io_oper.h
@@ -43,6 +43,9 @@ typedef loff_t  offset_t;
 #define MMAP_FILE_SIZE (200 * KB)
 extern char fsync_flag;
 
+#define IO_DONE             0
+#define IO_IN_PROGRESS      1
+
 #ifdef __CAPI_FLASH__
 
 


### PR DESCRIPTION
Problem:
------------
hxestorage exerciser reporting IO hung:
Before starting any IO. each thread will create an entry of LBA no.s where it is going to do IO and the current time. This entry will be there till the time thread finished its entire operation e.g. "WRC". Once, entire operation is done, entry will be removed.In the meantime, hang_monitor thread will keep on scanning all the entries at regular interval. If it finds any entry older than 10 min. it will report that IO is hung. Problem here is, the time should not be considered for the entire operation. It should be for each inidividual IO in that.
Solution:
------------
This needed a design change as below:
In the new design, the time taken will be considered for each individual IO in the operation. SO, entry in the array will be created before starting the operation to update the LBA range. But time will be updated only before starting the actual IO operation and a flag will be set to inform that IO is in progress. The difference of this time and current time will be taken into consideration only when "IO in progress" flag will be set.
