### PR TITLE
time driven feature: in inc lib htxd hxediag

### DIFF
--- a/bin/htxd/Makefile
+++ b/bin/htxd/Makefile
@@ -26,6 +26,7 @@ htxd_OBJECTS = htxd.o \
 		htxd_exer${OBJ_SUFF} \
 		htxd_thread${OBJ_SUFF} \
 		htxd_hang_monitor${OBJ_SUFF} \
+		htxd_time_driven_run_monitor${OBJ_SUFF} \
 		htxd_dr${OBJ_SUFF} \
 		htxd_hotplug${OBJ_SUFF} \
 		htxd_equaliser${OBJ_SUFF} \

--- a/bin/htxd/htxd.h
+++ b/bin/htxd/htxd.h
@@ -1,12 +1,12 @@
 /* IBM_PROLOG_BEGIN_TAG */
-/* 
+/*
  * Copyright 2003,2016 IBM International Business Machines Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * 		 http://www.apache.org/licenses/LICENSE-2.0
+ *               http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 /* IBM_PROLOG_END_TAG */
-/* @(#)35	1.5  src/htx/usr/lpp/htx/bin/htxd/htxd.h, htxd, htxubuntu 11/24/15 23:59:18 */
+
+
+/* @(#)35	1.14  src/htx/usr/lpp/htx/bin/htxd/htxd.h, htxd, htxubuntu, htxubuntu_497 10/4/18 03:57:51 */
 
 
 
@@ -41,7 +43,7 @@
 #define		HTXD_TRACE_LOW			1
 #define		HTXD_TRACE_MEDIUM		2
 #define		HTXD_TRACE_HIGH			3
-
+#define 	TIME_DRIVEN_RUN_MONITOR_PERIOD	1
 
 typedef struct
 {
@@ -59,6 +61,7 @@ typedef struct
 	htxd_thread *		p_hang_monitor_thread;
 	htxd_thread *		p_hotplug_monitor_thread;
 	htxd_thread 		stop_watch_monitor_thread;
+	htxd_thread *		p_time_driven_run_monitor_thread;
 	char		program_name[80];
 	char		htx_path[80];
 	int			shutdown_flag;
@@ -99,6 +102,8 @@ typedef struct
 extern htxd *htxd_global_instance;
 
 extern int htxd_start_daemon(htxd*);
+
+extern int get_exec_time_value_from_shm_hdr();
 
 #ifdef __HTX_LINUX__
 	extern int smt, bind_th_num;

--- a/bin/htxd/htxd_daemon.c
+++ b/bin/htxd/htxd_daemon.c
@@ -1,12 +1,12 @@
 /* IBM_PROLOG_BEGIN_TAG */
-/* 
+/*
  * Copyright 2003,2016 IBM International Business Machines Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * 		 http://www.apache.org/licenses/LICENSE-2.0
+ *               http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 /* IBM_PROLOG_END_TAG */
+
+
 /* @(#)38	1.8  src/htx/usr/lpp/htx/bin/htxd/htxd_daemon.c, htxd, htxfedora 9/15/15 20:28:01 */
 
 
@@ -287,6 +289,15 @@ int htxd_idle_daemon(void)
 		htxd_remove_hang_monitor();
 
 		sprintf(trace_string, "stopping hang monitor thread");
+		HTXD_TRACE(LOG_OFF, trace_string);
+	}
+	
+	if(htxd_is_time_driven_run_monitor_initialized() == TRUE) {
+		htxd_instance = htxd_get_instance();
+		htxd_stop_time_driven_run_monitor(&(htxd_instance->p_time_driven_run_monitor_thread));
+		htxd_remove_time_driven_run_monitor();
+
+		sprintf(trace_string, "stopping time_driven_run monitor thread");
 		HTXD_TRACE(LOG_OFF, trace_string);
 	}
 

--- a/bin/htxd/htxd_define.h
+++ b/bin/htxd/htxd_define.h
@@ -1,12 +1,12 @@
 /* IBM_PROLOG_BEGIN_TAG */
-/* 
+/*
  * Copyright 2003,2016 IBM International Business Machines Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * 		 http://www.apache.org/licenses/LICENSE-2.0
+ *               http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 /* IBM_PROLOG_END_TAG */
-/* @(#)39	1.4  src/htx/usr/lpp/htx/bin/htxd/htxd_define.h, htxd, htxubuntu 9/15/15 20:28:07 */
+
+
+/* @(#)39	1.13  src/htx/usr/lpp/htx/bin/htxd/htxd_define.h, htxd, htxubuntu, htxubuntu_497 10/4/18 04:49:34 */
 
 
 
@@ -123,7 +125,7 @@
 #define HTXD_MDT_SHUTDOWN_MSG	190
 
 #define HTXD_HTX_PROCESS_FOUND 51
-
+#define HTXD_TIME_DRIVEN_EXIT 52
 
 /* daemon states */
 #define		HTXD_DAEMON_STATE_IDLE			1

--- a/bin/htxd/htxd_instance.c
+++ b/bin/htxd/htxd_instance.c
@@ -1,12 +1,12 @@
 /* IBM_PROLOG_BEGIN_TAG */
-/* 
+/*
  * Copyright 2003,2016 IBM International Business Machines Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * 		 http://www.apache.org/licenses/LICENSE-2.0
+ *               http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 /* IBM_PROLOG_END_TAG */
-/* @(#)48	1.9  src/htx/usr/lpp/htx/bin/htxd/htxd_instance.c, htxd, htxubuntu 11/24/15 23:59:21 */
+
+
+/* @(#)48	1.22  src/htx/usr/lpp/htx/bin/htxd/htxd_instance.c, htxd, htxubuntu, htxubuntu_497 10/4/18 04:37:25 */
 
 
 
@@ -410,6 +412,19 @@ int htxd_is_hang_monitor_initialized(void)
 	}
 }
 
+int htxd_is_time_driven_run_monitor_initialized(void)
+{
+	htxd *p_temp_instance;
+
+	p_temp_instance = htxd_get_instance();
+
+	if(p_temp_instance->p_time_driven_run_monitor_thread == 0) {
+		return FALSE;
+	} else {
+		return TRUE;
+	}
+}
+
 
 void htxd_remove_hang_monitor(void)
 {
@@ -420,7 +435,14 @@ void htxd_remove_hang_monitor(void)
 	p_temp_instance->p_hang_monitor_thread = 0;
 }
 
+void htxd_remove_time_driven_run_monitor(void)
+{
+	htxd *p_temp_instance;
 
+	p_temp_instance = htxd_get_instance();
+
+	p_temp_instance->p_time_driven_run_monitor_thread = 0;
+}
 
 int htxd_is_stop_watch_monitor_initialized(void)
 {
@@ -525,6 +547,7 @@ void init_htxd_instance(htxd *p_htxd_instance)
 	p_htxd_instance->dr_is_done			= 0;
 	p_htxd_instance->dr_child_pid			= 0;
 	p_htxd_instance->p_hang_monitor_thread		= NULL;
+	p_htxd_instance->p_time_driven_run_monitor_thread		= NULL;
 	p_htxd_instance->p_hotplug_monitor_thread	= NULL;
 	p_htxd_instance->equaliser_debug_flag		= 0;
 	p_htxd_instance->is_auto_started		= 0;

--- a/bin/htxd/htxd_option_method_misc.c
+++ b/bin/htxd/htxd_option_method_misc.c
@@ -1,12 +1,12 @@
 /* IBM_PROLOG_BEGIN_TAG */
-/* 
+/*
  * Copyright 2003,2016 IBM International Business Machines Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * 		 http://www.apache.org/licenses/LICENSE-2.0
+ *               http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 /* IBM_PROLOG_END_TAG */
-/* @(#)56	1.6  src/htx/usr/lpp/htx/bin/htxd/htxd_option_method_misc.c, htxd, htxubuntu 9/15/15 20:28:32 */
+
+
+/* @(#)56	1.25  src/htx/usr/lpp/htx/bin/htxd/htxd_option_method_misc.c, htxd, htxubuntu, htxubuntu_497 10/4/18 04:06:01 */
 
 
 
@@ -48,7 +50,6 @@ extern int htxd_run_HE_script(char *, char *, int *);
 extern int htxd_get_ecg_list_length(htxd_ecg_manager *);
 extern int htxd_load_exerciser(struct htxshm_HE *);
 extern int htxd_get_common_command_result(int, htxd_ecg_info *, char *, char *);
-
 
 int htxd_expand_device_name_list(htxd_ecg_info *p_ecg_info_list, char *device_name_list)
 {
@@ -145,6 +146,8 @@ int htxd_get_device_run_status(struct htxshm_HE *p_HE, htxd_ecg_info *p_ecg_info
 	int device_sem_status;
 	int device_sem_id;
 
+//	struct htxshm_hdr *p_hdr;
+//	p_hdr = (p_ecg_info->ecg_shm_addr.hdr_addr);
 
 	if(status_result == NULL) {
 		return -1;
@@ -156,7 +159,9 @@ int htxd_get_device_run_status(struct htxshm_HE *p_HE, htxd_ecg_info *p_ecg_info
 	if( (p_ecg_info->ecg_shm_addr.hdr_addr->started == 0)&& (p_HE->is_child) ) {
 			strcpy(status_result, "  ");
 	} else if(p_HE->PID == 0) {
-		if(p_HE->DR_term == 1) {
+		if(p_HE->sp3 == 1) {
+			strcpy(status_result, "TE");/*timed exit*/
+		}else if(p_HE->DR_term == 1) {
 			strcpy(status_result, "DT");
 		} else if(p_HE->test_run_period_expired == 1) {
 			strcpy(status_result, "RT");
@@ -180,7 +185,7 @@ int htxd_get_device_run_status(struct htxshm_HE *p_HE, htxd_ecg_info *p_ecg_info
 		strcpy(status_result, "SD");
 	} else if( (p_HE->max_cycles != 0) && (p_HE->cycles >= p_HE->max_cycles) ) {
 		strcpy(status_result, "CP");
-	} else if( (epoch_time_now - p_HE->tm_last_upd) > ( (long)(p_HE->max_run_tm + p_HE->idle_time) ) ) {  ////?????
+	} else if( (epoch_time_now - p_HE->tm_last_upd) > ( (long)(p_HE->max_run_tm + p_HE->idle_time) ) ) { 
 		strcpy(status_result, "HG");
 	} else if( (p_HE->max_cycles != 0 ) && (p_HE->cycles >= p_HE->max_cycles) ) {
 		strcpy(status_result, "PR");
@@ -3587,5 +3592,7 @@ int htxd_option_method_get_dev_cycles(char **command_result, htxd_command *p_com
 
 	return 0;
 }
+
+
 
 

--- a/bin/htxd/htxd_time_driven_run_monitor.c
+++ b/bin/htxd/htxd_time_driven_run_monitor.c
@@ -1,0 +1,181 @@
+/* IBM_PROLOG_BEGIN_TAG */
+/*
+ * Copyright 2003,2016 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *               http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* IBM_PROLOG_END_TAG */
+
+
+/* @(#)47   1.9  src/htx/usr/lpp/htx/bin/htxd/htxd_hang_monitor.c, htxd, htxubuntu 11/23/17 23:36:55 */
+
+
+
+#include <stdio.h>
+
+
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <errno.h>
+#include <signal.h>
+
+#include "htxd.h"
+#include "htxd_ecg.h"
+#include "htxd_thread.h"
+#include "htxd_profile.h"
+#include "htxd_trace.h"
+#include "htxd_util.h"
+#include "htxd_instance.h"
+
+#define LOG_ENTRY_COUNT 6  /* 5 + 1 */
+
+
+extern htxd *htxd_global_instance;
+extern volatile int htxd_shutdown_flag;
+int cycles_complete_flag = FALSE;
+
+int htxd_time_driven_run_monitor_ecg(htxd_ecg_info *p_ecg_info_to_time_driven_run_monitor, char *command_result)
+{
+    struct htxshm_HE *p_HE;
+    struct htxshm_hdr *p_hdr;
+    int i;
+    time_t epoch_time_now;
+    char time_driven_run_monitor_log_entry[512];
+    int first_time_TE_flag = 0;
+
+    /* wait while ECG get active */
+    while(p_ecg_info_to_time_driven_run_monitor->ecg_status != ECG_ACTIVE) {
+        sleep(5);
+    }
+
+    epoch_time_now = time( (time_t *) 0);
+
+    p_HE = (struct htxshm_HE *)(p_ecg_info_to_time_driven_run_monitor->ecg_shm_addr.hdr_addr + 1);
+
+    p_hdr = p_ecg_info_to_time_driven_run_monitor->ecg_shm_addr.hdr_addr;
+
+    for(i = 0; i < p_ecg_info_to_time_driven_run_monitor->ecg_shm_exerciser_entries ; i++) {
+
+        if(p_HE->max_cycles != 0) {
+            if(p_HE->cycles <  p_HE->max_cycles) {
+                cycles_complete_flag = FALSE;
+            }else {
+                cycles_complete_flag = TRUE;
+            }
+        } else {
+            cycles_complete_flag = FALSE;
+        }
+
+        if(p_HE->PID == 0) {
+            if(p_HE->sp3 == 1) {/*set_stop_flag_in_exer_shm sets the sp3 after time_driven value is reached*/
+                first_time_TE_flag = 1;
+            }
+        }
+        if( (p_HE->PID != 0) &&
+            (p_HE->tm_last_upd != 0) &&
+            (cycles_complete_flag == FALSE)  &&
+            (htxd_get_device_run_sem_status(p_ecg_info_to_time_driven_run_monitor->ecg_sem_id, i) == 0) &&
+            (htxd_get_device_error_sem_status(p_ecg_info_to_time_driven_run_monitor->ecg_sem_id, i) == 0) &&
+            (p_HE->hung_exer == 0) &&
+            (p_HE->sp2 == 0) &&  /*sp2 flag is set for exercisers which supports time driven, it's done inside library when htx_start is called, hence those exercisers will exit by itself*/
+            (p_ecg_info_to_time_driven_run_monitor->ecg_shm_addr.hdr_addr->started != 0)&&
+            ( ((epoch_time_now -  atoi(htxd_get_ecg_start_time())) > (p_hdr->time_of_exec)) && (p_hdr->time_of_exec != 0) &&( first_time_TE_flag ==1) )) {
+                p_HE->sp3 = 1;
+                htxd_send_SIGTERM(p_HE->PID);
+                sprintf(time_driven_run_monitor_log_entry, "%s for %s received SIGTERM from htxd_time_driven_run_monitor!\n", p_HE->HE_name, p_HE->sdev_id);
+                htxd_send_message(time_driven_run_monitor_log_entry, 0, HTX_HE_SOFT_ERROR, HTX_SYS_MSG);
+        }
+        p_HE++;
+    }
+
+    return 0;
+}
+
+void *htxd_time_driven_run_monitor(void *data)
+{
+
+    htxd_enable_thread_cancel_state_type();
+
+    sleep(10); /* wait for system start up */
+
+    do {
+        htxd_process_all_active_ecg(htxd_time_driven_run_monitor_ecg, NULL);
+        sleep(TIME_DRIVEN_RUN_MONITOR_PERIOD);
+    } while(htxd_shutdown_flag == FALSE);
+
+    return NULL;
+}
+
+/* start time_driven_run_monitor thread */
+int htxd_start_time_driven_run_monitor(htxd_thread **time_driven_run_monitor_thread)
+{
+    int rc = 0, return_code = -1;
+    char temp_str[128];
+
+    if(*time_driven_run_monitor_thread == NULL) {
+        *time_driven_run_monitor_thread= malloc(sizeof(htxd_thread));
+        if(*time_driven_run_monitor_thread== NULL) {
+            sprintf(temp_str, "time_driven_run_monitor_thread: filed malloc with errno <%d>.\n", errno);
+            htxd_send_message(temp_str, 0, HTX_SYS_INFO, HTX_SYS_MSG);
+            exit(1);
+        }
+        memset(*time_driven_run_monitor_thread, 0, sizeof(htxd_thread));
+
+        (*time_driven_run_monitor_thread)->thread_function = htxd_time_driven_run_monitor;
+        (*time_driven_run_monitor_thread)->thread_data = NULL;
+
+        return_code = htxd_thread_create(*time_driven_run_monitor_thread);
+    #ifdef __HTX_LINUX__
+        if ((htxd_get_equaliser_offline_cpu_flag()) == 1) {
+            rc = do_the_bind_thread((*time_driven_run_monitor_thread)->thread_id);
+            if (rc < 0) {
+                sprintf(temp_str, "binding time_driven_run monitor process to core 0 failed.\n");
+                htxd_send_message(temp_str, 0, HTX_SYS_INFO, HTX_SYS_MSG);
+            }
+
+        }
+    #endif
+    }
+    return return_code;
+}
+
+/* stop time_driven_run  monitor thread */
+int htxd_stop_time_driven_run_monitor(htxd_thread **time_driven_run_monitor_thread)
+{
+    int return_code = -1;
+    char trace_string[256];
+
+
+    return_code = htxd_thread_cancel(*time_driven_run_monitor_thread);
+    if(return_code != 0) {
+        sprintf(trace_string, "htxd_stop_time_driven_run_monitor_thread : htxd_thread_cancel returned with <%d>", return_code);
+        HTXD_TRACE(LOG_ON, trace_string);
+    }
+
+    return_code = htxd_thread_join(*time_driven_run_monitor_thread);
+    if(return_code != 0) {
+        sprintf(trace_string, "htxd_stop_time_driven_run_monitor_thread: htxd_thread_join returned with <%d>", return_code);
+        HTXD_TRACE(LOG_ON, trace_string);
+    }
+
+    if(*time_driven_run_monitor_thread!= NULL) {
+        free(*time_driven_run_monitor_thread);
+        *time_driven_run_monitor_thread= NULL;
+    }
+
+    return return_code;
+}
+

--- a/bin/hxediag/hxediag.h
+++ b/bin/hxediag/hxediag.h
@@ -17,6 +17,8 @@
  */
 /* IBM_PROLOG_END_TAG */
 
+/* static char sccsid[] = "@(#)83	1.6  src/htx/usr/lpp/htx/bin/hxediag/hxediag.h, exer_diag, htxubuntu 5/23/17 06:16:18";  */
+
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -58,18 +60,6 @@
 #define LASSEN				6
 
 #define MAX_RETRY	0x10
-
-#define NVRAM_MASK 	0x01
-#define LINK_MASK 	0x02
-#define REGISTER_MASK 	0x04 
-#define MEMORY_MASK 	0x08
-#define MAC_MASK 	0x10 
-#define PHY_MASK 	0x20
-#define INT_LOOP_MASK 	0x40
-#define EXT_MASK 	0x80
-#define INTERRUPT_MASK 	0x100
-#define SPEED_MASK 	0x200
-#define LOOPBACK_MASK 	0x400
 
 #ifdef DEBUGON
 	#define DEBUG TRUE 
@@ -120,7 +110,7 @@ struct rule_info {
 	int num_oper; 
 	int sleep; 
 	int threshold; 
-	int mask;
+
 }; 
 
 /****************************************************
@@ -132,7 +122,7 @@ int issue_ioctl(int fd, void  * command , struct htx_data * htx_d);
 
 char * strupr(char * str); 
 
-int update_result(struct ethtool_test *test, int num_tests,  char supported_test[][MSG_TEXT_SIZE], int error_mask, struct self_test * self_test, struct htx_data * htx_d);
+int update_result(struct ethtool_test *test, int num_tests,  char supported_test[][MSG_TEXT_SIZE], struct self_test * self_test, struct htx_data * htx_d);
 
 int dump_test(struct ethtool_test *test, struct ethtool_gstrings *strings);
 

--- a/inc/htxlibdef.h
+++ b/inc/htxlibdef.h
@@ -17,6 +17,7 @@
  */
 /* IBM_PROLOG_END_TAG */
 
+
 /* @(#)44  1.9  src/htx/usr/lpp/htx/inc/htxlibdef.h, htx_libhtx, htx530 10/19/03 23:37:48 */
 /* Component = htx_libhtx_lx */
 
@@ -306,6 +307,23 @@ struct tm *htx_localtime_r (const time_t *timep, struct tm *result);
 int exer_err_halt_status(struct htx_data *data);
 
 int do_trap_htx64(unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long,unsigned long,unsigned long);
+
+int get_exec_time_value_from_shm_hdr( struct htx_data *data);
+
+double get_start_and_current_time_diff(void);
+
+typedef struct {
+        volatile int no_of_stanzas_to_be_executed;
+        volatile int time_interval_for_stanza_switch;
+        volatile int time_out_flag;
+        volatile struct htx_data *hd;
+        volatile int *exit_flag;
+}time_diff_func_struct;
+
+void* get_time_diff_function(time_diff_func_struct *time_diff_func_struct);
+
+extern time_diff_func_struct time_diff_struct;
+
 #endif
 
 static const char IBM_copyright_string[]="\n\

--- a/inc/hxiipc.h
+++ b/inc/hxiipc.h
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 /* IBM_PROLOG_END_TAG */
+
+
 /* @(#)47  1.34.4.8  src/htx/usr/lpp/htx/inc/hxiipc.h, htx_libhtx, htxfedora 12/16/14 03:58:17 */
 /* Component = htx_libhtx_;x */
 
@@ -165,6 +167,7 @@ struct htxshm_hdr {
         unsigned int  num_entries;       /* # of entries currently in shm   */
         unsigned short pseudo_entries;    /* # of pseudo entries cur. in shm */
         unsigned short pseudo_entry_0;    /* index to first pseudo entry     */
+	unsigned int    time_of_exec;	/*the time_driven value fetched from htxd run command*/
 
 #ifdef HTX_REL_tu320
         struct         hft_devs {         /* hft devices...................  */


### PR DESCRIPTION
**Background :**
•HTX runs infinitely unless stopped
•Time driven execution allows to complete all testcases in specified amount of time
•Guaranteed test coverage with no increase in test time
•Beneficial to shorter test duration assured test coverage (for e.g. DevOPs, regression)

![image](https://user-images.githubusercontent.com/18320790/48393619-54196200-e736-11e8-88b0-9316394bd0e3.png)

**Features and points to remember**

Run mdt.bu under htxcmdline with an argument passed along with the run command which specifies the amount of time you want to run

All exercisers in mdt.bu will complete at least one cycle covering all stanzas within the given time period, with every stanza being executed for equal amount of time

Any exerciser running with htx lib linked will be stopped forcefully at the specified time

Cycles will roll over after every hour. I.e. Every one hour, one cycle will be completed.

 **Usage**

To start a time driven run, use the following option

**htxcmdline -run time <time in seconds> -ecg mdt.bu**

'time' should be followed by the amount of time you want to run HTX in seconds

Eg:

htxcmdline -run time 300 -ecg mdt.bu 

 

In case of any issue, please contact:

vishnur1@in.ibm.com
