### PR TITLE
to add check for perl link creation during HTX install

### DIFF
--- a/packaging/installer.sh
+++ b/packaging/installer.sh
@@ -140,7 +140,7 @@ echo -ne "\nFinishing Installation..." | tee -a ${INSTALL_LOG_FILE}
 [[ -f $INSTALL_PATH/htx/etc/scripts/htx.d ]] && cp -f $INSTALL_PATH/htx/etc/scripts/htx.d /etc/init.d
 echo -e "[OK]" | tee -a ${INSTALL_LOG_FILE}
 echo -ne "\nCopying HTX Binaries..." | tee -a ${INSTALL_LOG_FILE}
-[[ -f /bin/perl ]] && ln -sf /usr/bin/perl /bin/perl >> ${INSTALL_LOG_FILE} 2>&1
+[[ -f /bin/perl ]] && ln -s /usr/bin/perl /bin/perl >> ${INSTALL_LOG_FILE} 2>&1
 if [ "$OS" != "RedHat" ];
 then 
 	ln -sf /usr/bin/awk /bin/awk >> ${INSTALL_LOG_FILE} 2>&1

--- a/packaging/installer.sh
+++ b/packaging/installer.sh
@@ -140,7 +140,7 @@ echo -ne "\nFinishing Installation..." | tee -a ${INSTALL_LOG_FILE}
 [[ -f $INSTALL_PATH/htx/etc/scripts/htx.d ]] && cp -f $INSTALL_PATH/htx/etc/scripts/htx.d /etc/init.d
 echo -e "[OK]" | tee -a ${INSTALL_LOG_FILE}
 echo -ne "\nCopying HTX Binaries..." | tee -a ${INSTALL_LOG_FILE}
-ln -sf /usr/bin/perl /bin/perl >> ${INSTALL_LOG_FILE} 2>&1
+[[ -f /bin/perl ]] && ln -sf /usr/bin/perl /bin/perl >> ${INSTALL_LOG_FILE} 2>&1
 if [ "$OS" != "RedHat" ];
 then 
 	ln -sf /usr/bin/awk /bin/awk >> ${INSTALL_LOG_FILE} 2>&1

--- a/packaging/ubuntu/DEBIAN/postinst
+++ b/packaging/ubuntu/DEBIAN/postinst
@@ -7,7 +7,7 @@ case "$1" in
 		mkdir -p /var/log
 		echo "/usr/lpp/htx" > /var/log/htx_install_path	
 		[[ -f /usr/lpp/htx/etc/scripts/htx.d ]] && cp -f /usr/lpp/htx/etc/scripts/htx.d /etc/init.d
-		ln -sf /usr/bin/perl /bin/perl
+		[[ -f /bin/perl ]] || ln -sf /usr/bin/perl /bin/perl
 		ln -sf /usr/bin/awk /bin/awk
 		ln -sf /usr/lpp/htx/bin/htxcmdline /bin/htxcmdline
 		ln -sf /usr/lpp/htx/bin/htxcmdline /bin/hcl

--- a/packaging/ubuntu/DEBIAN/postinst
+++ b/packaging/ubuntu/DEBIAN/postinst
@@ -7,7 +7,7 @@ case "$1" in
 		mkdir -p /var/log
 		echo "/usr/lpp/htx" > /var/log/htx_install_path	
 		[[ -f /usr/lpp/htx/etc/scripts/htx.d ]] && cp -f /usr/lpp/htx/etc/scripts/htx.d /etc/init.d
-		[[ -f /bin/perl ]] || ln -sf /usr/bin/perl /bin/perl
+		[[ -f /bin/perl ]] || ln -s /usr/bin/perl /bin/perl
 		ln -sf /usr/bin/awk /bin/awk
 		ln -sf /usr/lpp/htx/bin/htxcmdline /bin/htxcmdline
 		ln -sf /usr/lpp/htx/bin/htxcmdline /bin/hcl


### PR DESCRIPTION
To avoid perl soft link creation issue with HTX install, a new check is added in HTX installer, before creating the new perl soft link.